### PR TITLE
install.sh: persist only what is ours — a firewall unit instead of iptables-persistent, scoped sysctl instead of --system

### DIFF
--- a/.changeset/metal-donkeys-refuse.md
+++ b/.changeset/metal-donkeys-refuse.md
@@ -1,0 +1,5 @@
+---
+'@dormice/cli': patch
+---
+
+`dor doctor` gains a `net.ipv4.ip_forward` check: fail when forwarding is off (sandboxes have no network right now), warn when it is on but the boot config would turn it off at the next sysctl replay — naming the offending file. The firewall-persistence check now recognizes the `dormice-metadata-firewall` systemd unit that install.sh writes instead of `iptables-persistent` (hosts persisted the old way still pass), and the swappiness fix no longer suggests `sysctl --system`, which replays unrelated operator settings.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -276,20 +276,50 @@ else
   note "created a ${SWAP_GB} GiB /swapfile, persisted in /etc/fstab"
 fi
 
-# ---- vm.swappiness = 100 ----------------------------------------------------
-# gVisor holds sandbox memory as shared memory, which the kernel refuses to
-# swap below swappiness 100 (measured at 60: 0 bytes reclaimed). The file is
-# named to sort after cloud-vendor sysctl.d files that ship swappiness=0.
-log 'vm.swappiness = 100'
-if [ "$(cat /proc/sys/vm/swappiness)" = 100 ]; then
-  note '[skip] effective value is already 100'
+# ---- kernel parameters (sysctl) ----------------------------------------------
+# vm.swappiness=100: gVisor holds sandbox memory as shared memory, which the
+# kernel refuses to swap below swappiness 100 (measured at 60: 0 bytes
+# reclaimed). net.ipv4.ip_forward=1: bridge networking dies without it, and
+# although dockerd flips it on at every daemon start, a boot config that says
+# 0 comes back at the next config replay and silently cuts every sandbox's
+# network. The file is named to sort after cloud-vendor sysctl.d files that
+# ship swappiness=0. Applied scoped — `sysctl --system` here would replay
+# every operator setting mid-install (an ip_forward=0 in /etc/sysctl.conf did
+# exactly that and killed the base-image build two steps later). Boot-order
+# effectiveness is verified against systemd-sysctl's own application order:
+# the winning value of each key must be the one we need. The value, not the
+# file — a host may legitimately set ip_forward=1 in its own later-sorting
+# config (the test host does), and that is agreement, not a conflict.
+log 'kernel parameters (vm.swappiness = 100, net.ipv4.ip_forward = 1)'
+SYSCTL_FILE=/etc/sysctl.d/99-dormice.conf
+sysctl_wanted='# Managed by Dormice install.sh — rewritten on every run.
+vm.swappiness=100
+net.ipv4.ip_forward=1'
+if [ "$(cat "$SYSCTL_FILE" 2>/dev/null)" = "$sysctl_wanted" ]; then
+  note "[skip] $SYSCTL_FILE is in place"
 else
-  echo 'vm.swappiness=100' >/etc/sysctl.d/99-dormice.conf
-  sysctl --system >/dev/null
-  [ "$(cat /proc/sys/vm/swappiness)" = 100 ] \
-    || die 'wrote /etc/sysctl.d/99-dormice.conf but the effective value still is not 100 — something later in sysctl order overrides it'
-  note 'set via /etc/sysctl.d/99-dormice.conf (survives reboot)'
+  printf '%s\n' "$sysctl_wanted" >"$SYSCTL_FILE"
+  note "wrote $SYSCTL_FILE (survives reboot)"
 fi
+sysctl -p "$SYSCTL_FILE" >/dev/null
+systemd_sysctl=/usr/lib/systemd/systemd-sysctl
+[ -x "$systemd_sysctl" ] || systemd_sysctl=/lib/systemd/systemd-sysctl
+[ -x "$systemd_sysctl" ] \
+  || die 'cannot find systemd-sysctl to verify the sysctl boot order — non-systemd hosts are not supported'
+for kv in vm.swappiness=100 net.ipv4.ip_forward=1; do
+  key=${kv%%=*} want=${kv#*=}
+  winner=$("$systemd_sysctl" --cat-config | awk -v key="$key" '
+    /^# \//       { file = $2; next }
+    /^[ \t]*[#;]/ { next }
+    {
+      eq = index($0, "="); if (eq == 0) next
+      k = substr($0, 1, eq - 1); gsub(/[ \t]/, "", k); sub(/^-/, "", k); gsub("/", ".", k)
+      if (k == key) { v = substr($0, eq + 1); gsub(/[ \t]/, "", v); print file " " v }
+    }' | tail -n 1)
+  [ "${winner#* }" = "$want" ] \
+    || die "$key must be $want at boot, but the sysctl boot order ends with ${winner% *} setting it to ${winner#* } — change or remove that line, then re-run"
+done
+note 'verified: the sysctl boot order ends with our values for both keys'
 
 # ---- cloud metadata firewall -------------------------------------------------
 # Sandboxes run untrusted code; on a cloud host with an attached role, one
@@ -306,16 +336,45 @@ for target in 169.254.0.0/16 100.100.100.200; do
   fi
 done
 if [ -n "$added" ]; then note "added DROP rules:$added"; else note '[skip] both DROP rules present'; fi
-if ! grep -qs 100.100.100.200 /etc/iptables/rules.v4; then
-  # Preseeded so apt never prompts; the explicit save below is what persists.
-  echo 'iptables-persistent iptables-persistent/autosave_v4 boolean true' | debconf-set-selections
-  echo 'iptables-persistent iptables-persistent/autosave_v6 boolean true' | debconf-set-selections
-  command -v netfilter-persistent >/dev/null || { apt-get update -q; apt-get install -qy iptables-persistent; }
-  netfilter-persistent save >/dev/null 2>&1
-  note 'persisted to /etc/iptables/rules.v4 (survives reboot)'
+# Persistence is our own oneshot unit that re-adds the rules after docker
+# creates the DOCKER-USER chain at boot (docker never flushes that chain
+# afterwards). Deliberately NOT iptables-persistent: installing it makes apt
+# remove ufw (the packages conflict) — silently discarding an operator's
+# firewall — and `netfilter-persistent save` snapshots the whole ruleset,
+# operator rules and Docker's ephemeral NAT entries included, when exactly
+# two rules are ours to persist. Hosts persisted the old way keep their
+# /etc/iptables/rules.v4 untouched; the -C checks make duplicates impossible.
+FIREWALL_UNIT=/etc/systemd/system/dormice-metadata-firewall.service
+firewall_unit=$(cat <<'EOF'
+# Written by Dormice install.sh — rewritten on every run. Sandboxes run
+# untrusted code; these rules keep them away from the cloud metadata service.
+[Unit]
+Description=Dormice: block cloud metadata endpoints from containers
+After=docker.service
+Requires=docker.service
+Before=dormice.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c 'iptables -C DOCKER-USER -d 169.254.0.0/16 -j DROP 2>/dev/null || iptables -I DOCKER-USER -d 169.254.0.0/16 -j DROP'
+ExecStart=/bin/sh -c 'iptables -C DOCKER-USER -d 100.100.100.200 -j DROP 2>/dev/null || iptables -I DOCKER-USER -d 100.100.100.200 -j DROP'
+
+[Install]
+WantedBy=multi-user.target
+EOF
+)
+if [ "$(cat "$FIREWALL_UNIT" 2>/dev/null)" = "$firewall_unit" ]; then
+  note '[skip] persistence unit is in place'
 else
-  note '[skip] rules already persisted'
+  printf '%s\n' "$firewall_unit" >"$FIREWALL_UNIT"
+  systemctl daemon-reload
+  note "wrote $FIREWALL_UNIT (re-adds the rules after docker starts — survives reboot)"
 fi
+systemctl enable dormice-metadata-firewall >/dev/null 2>&1
+# Started now, not only at boot: a unit that has never run is an unproven
+# promise, and the start is a no-op when the rules are already in.
+systemctl restart dormice-metadata-firewall
 
 # ---- Dormice code -----------------------------------------------------------
 # Defined before the pull so the rollback in on_exit can always call it.

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -30,6 +30,17 @@ const DF_ROOMY =
   'Filesystem 1024-blocks Used Available Capacity Mounted on\n' +
   '/dev/vda3 200000000 50000000 150000000 25% /';
 
+// systemd-sysctl --cat-config output shape: a `# /path` line opens each
+// file, then that file's lines follow. Application order = boot order.
+const CAT_CONFIG_GOOD = [
+  '# /usr/lib/sysctl.d/50-default.conf',
+  'kernel.sysrq = 0x01b6',
+  '# /etc/sysctl.d/99-dormice.conf',
+  '# Managed by Dormice install.sh — rewritten on every run.',
+  'vm.swappiness=100',
+  'net.ipv4.ip_forward=1',
+].join('\n');
+
 /**
  * A whole healthy host, faked. Tests override single facts to break one
  * check at a time — the doctor equivalent of the contract suite's "one
@@ -50,6 +61,7 @@ function fakeHost(
     '/etc/docker/daemon.json': GOOD_DAEMON_JSON,
     '/proc/meminfo': 'MemTotal: 30000000 kB\nSwapTotal: 16777212 kB',
     '/proc/sys/vm/swappiness': '100\n',
+    '/proc/sys/net/ipv4/ip_forward': '1\n',
     '/etc/iptables/rules.v4': IPTABLES_GOOD,
     '/etc/caddy/Caddyfile':
       '# Managed by Dormice — setIngress rewrites this file.\n\n:80 {\n\treverse_proxy 127.0.0.1:3676\n}\n',
@@ -61,6 +73,8 @@ function fakeHost(
       '{"runc":{"path":"runc"},"runsc":{"path":"/usr/local/bin/runsc"}}',
     ),
     'iptables -S DOCKER-USER': ok(IPTABLES_GOOD),
+    'systemctl is-enabled dormice-metadata-firewall': ok('enabled\n'),
+    '/usr/lib/systemd/systemd-sysctl --cat-config': ok(CAT_CONFIG_GOOD),
     [`docker image inspect ${IMAGE}`]: ok('[{}]'),
     'df -Pk /var/lib/dormice': ok(DF_ROOMY),
     [`docker run --rm --runtime=runsc ${IMAGE} uname -r`]:
@@ -232,14 +246,89 @@ describe('metadata firewall', () => {
 
   it('rules present but not persisted is a warning, not a failure', async () => {
     const { results, failed } = await runDoctor(
-      fakeHost({ files: { '/etc/iptables/rules.v4': undefined } }),
+      fakeHost({
+        files: { '/etc/iptables/rules.v4': undefined },
+        commands: {
+          'systemctl is-enabled dormice-metadata-firewall': boom('disabled'),
+        },
+      }),
     );
     expect(results['metadata-persisted']).toMatchObject({
       status: 'warn',
-      fix: expect.stringContaining('iptables-persistent'),
+      fix: expect.stringContaining('install.sh'),
     });
     // Warnings alone never flip the exit code.
     expect(failed).toBe(false);
+  });
+
+  it('a pre-unit install persisted via iptables-persistent still passes', async () => {
+    const { results } = await runDoctor(
+      fakeHost({
+        commands: {
+          'systemctl is-enabled dormice-metadata-firewall': boom(
+            'Failed to get unit file state',
+          ),
+        },
+      }),
+    );
+    expect(results['metadata-persisted']).toMatchObject({
+      status: 'pass',
+      detail: expect.stringContaining('rules.v4'),
+    });
+  });
+});
+
+describe('sandbox networking (net.ipv4.ip_forward)', () => {
+  it('an effective 0 is a hard failure — sandboxes are cut right now', async () => {
+    const { results, failed } = await runDoctor(
+      fakeHost({ files: { '/proc/sys/net/ipv4/ip_forward': '0\n' } }),
+    );
+    expect(failed).toBe(true);
+    expect(results['ip-forward']).toMatchObject({
+      status: 'fail',
+      detail: expect.stringContaining('every sandbox is cut'),
+    });
+  });
+
+  it('effective 1 with a boot config saying 0 warns and names the file', async () => {
+    // The real incident: /etc/sysctl.conf shipped ip_forward=0, applied via
+    // Debian's 99-sysctl.conf symlink — which sorts after 99-dormice.conf.
+    const { results, failed } = await runDoctor(
+      fakeHost({
+        commands: {
+          '/usr/lib/systemd/systemd-sysctl --cat-config': ok(
+            [
+              '# /etc/sysctl.d/99-dormice.conf',
+              'vm.swappiness=100',
+              'net.ipv4.ip_forward=1',
+              '# /etc/sysctl.d/99-sysctl.conf',
+              'net.ipv4.ip_forward = 0',
+            ].join('\n'),
+          ),
+        },
+      }),
+    );
+    expect(failed).toBe(false);
+    expect(results['ip-forward']).toMatchObject({
+      status: 'warn',
+      detail: expect.stringContaining('99-sysctl.conf'),
+    });
+  });
+
+  it('effective 1 with no boot config at all passes — dockerd re-enables it', async () => {
+    const { results } = await runDoctor(
+      fakeHost({
+        commands: {
+          '/usr/lib/systemd/systemd-sysctl --cat-config': ok(
+            '# /usr/lib/sysctl.d/50-default.conf\nkernel.sysrq = 0x01b6\n',
+          ),
+        },
+      }),
+    );
+    expect(results['ip-forward']).toMatchObject({
+      status: 'pass',
+      detail: expect.stringContaining('dockerd re-enables'),
+    });
   });
 });
 

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -112,6 +112,34 @@ const DAEMON_JSON = '/etc/docker/daemon.json';
 const RULES_V4 = '/etc/iptables/rules.v4';
 const METADATA_IP = '100.100.100.200';
 const METADATA_RANGE = '169.254.0.0/16';
+const SYSCTL_FILE = '/etc/sysctl.d/99-dormice.conf';
+// Not on PATH; /lib is merged into /usr/lib on every supported target.
+const SYSTEMD_SYSCTL = '/usr/lib/systemd/systemd-sysctl';
+
+/**
+ * The file whose value for `key` wins at boot, parsed from
+ * `systemd-sysctl --cat-config` — the authoritative application order,
+ * with `# /path` lines marking each file. Last setter wins.
+ */
+function sysctlBootWinner(
+  catConfig: string,
+  key: string,
+): { file: string; value: string } | undefined {
+  let file = 'unknown';
+  let winner: { file: string; value: string } | undefined;
+  for (const line of catConfig.split('\n')) {
+    if (line.startsWith('# /')) {
+      file = line.slice(2).trim();
+      continue;
+    }
+    if (/^\s*[#;]/.test(line)) continue;
+    const eq = line.indexOf('=');
+    if (eq < 0) continue;
+    const k = line.slice(0, eq).trim().replace(/^-/, '').replaceAll('/', '.');
+    if (k === key) winner = { file, value: line.slice(eq + 1).trim() };
+  }
+  return winner;
+}
 
 async function daemonJson(
   ctx: DoctorContext,
@@ -289,8 +317,48 @@ const CHECKS: DoctorCheck[] = [
         ? pass('100 (effective value)')
         : fail(
             `effective value is ${value} — below 100 the kernel refuses to swap gVisor's shmem-held sandbox memory (measured at 60: 0 bytes reclaimed)`,
-            "echo 'vm.swappiness=100' > /etc/sysctl.d/99-dormice.conf && sysctl --system",
+            `re-run install.sh — it persists 100 in ${SYSCTL_FILE}, applies it scoped, and verifies nothing later in the sysctl boot order overrides it`,
           );
+    },
+  },
+  {
+    id: 'ip-forward',
+    title: 'net.ipv4.ip_forward = 1',
+    needs: ['os-linux'],
+    run: async (ctx) => {
+      const raw = await ctx.readTextFile('/proc/sys/net/ipv4/ip_forward');
+      const value = raw?.trim();
+      if (value === undefined)
+        return fail('cannot read /proc/sys/net/ipv4/ip_forward');
+      if (value !== '1') {
+        return fail(
+          `effective value is ${value} — bridge networking is off, every sandbox is cut from the network right now`,
+          `re-run install.sh — it persists 1 in ${SYSCTL_FILE}, applies it, and verifies the sysctl boot order`,
+        );
+      }
+      // 1 now proves little: dockerd flips it on at every daemon start. The
+      // hazard is a boot config that says 0 — the next config replay (some
+      // other installer's `sysctl --system`) re-applies it and cuts sandbox
+      // networking until dockerd restarts. Unlike swappiness, whose drift
+      // surfaces in the effective value after a reboot, this one can stay
+      // masked forever — so this check alone also reads the boot config, in
+      // systemd-sysctl's own application order.
+      const res = await ctx.run(SYSTEMD_SYSCTL, ['--cat-config']);
+      if (!res.ok) {
+        return pass('1 (effective value; boot config unreadable here)');
+      }
+      const winner = sysctlBootWinner(res.stdout, 'net.ipv4.ip_forward');
+      if (winner !== undefined && winner.value !== '1') {
+        return warn(
+          `1 now, but ${winner.file} sets ${winner.value} at boot — the next sysctl config replay cuts every sandbox's networking`,
+          `drop net.ipv4.ip_forward from ${winner.file}, or re-run install.sh and let it verify the boot order`,
+        );
+      }
+      return pass(
+        winner === undefined
+          ? '1 (effective value; no boot config sets it — dockerd re-enables it at every start)'
+          : `1 (effective value, persisted by ${winner.file})`,
+      );
     },
   },
   {
@@ -325,13 +393,25 @@ const CHECKS: DoctorCheck[] = [
     title: 'firewall rules persisted',
     needs: ['metadata-firewall'],
     run: async (ctx) => {
+      const unit = await ctx.run('systemctl', [
+        'is-enabled',
+        'dormice-metadata-firewall',
+      ]);
+      if (unit.ok) {
+        return pass(
+          'dormice-metadata-firewall.service re-adds the rules after docker starts',
+        );
+      }
+      // Pre-unit installs persisted via iptables-persistent — still real
+      // persistence, not drift to repair.
       const rules = await ctx.readTextFile(RULES_V4);
-      return rules?.includes(METADATA_IP) && rules.includes('169.254')
-        ? pass(`both rules in ${RULES_V4}`)
-        : warn(
-            'the DROP rules live only in memory — a reboot silently drops them',
-            'apt-get install -y iptables-persistent && netfilter-persistent save',
-          );
+      if (rules?.includes(METADATA_IP) && rules.includes('169.254')) {
+        return pass(`both rules in ${RULES_V4} (iptables-persistent)`);
+      }
+      return warn(
+        'the DROP rules live only in memory — a reboot silently drops them',
+        're-run install.sh (it writes the dormice-metadata-firewall systemd unit)',
+      );
     },
   },
   {

--- a/packages/console/src/features/doctor/fixtures.ts
+++ b/packages/console/src/features/doctor/fixtures.ts
@@ -88,6 +88,12 @@ export const SAMPLE_DOCTOR: DoctorReport = {
         '直读 /proc/sys/vm/swappiness 的生效值 — gVisor 的共享内存低于 100 挤不出去',
     },
     {
+      id: 'ip-forward',
+      title: 'net.ipv4.ip_forward = 1',
+      status: 'pass',
+      detail: '生效值 1,且 /etc/sysctl.d/99-dormice.conf 在启动序中胜出',
+    },
+    {
       id: 'metadata-firewall',
       title: '云元数据防火墙',
       status: 'pass',
@@ -97,7 +103,7 @@ export const SAMPLE_DOCTOR: DoctorReport = {
       id: 'metadata-persisted',
       title: '防火墙规则已持久化',
       status: 'pass',
-      detail: '/etc/iptables/rules.v4 在,重启不丢',
+      detail: 'dormice-metadata-firewall.service 开机在 docker 之后补规则',
     },
     {
       id: 'api-token',

--- a/website/content/docs/doctor.mdx
+++ b/website/content/docs/doctor.mdx
@@ -60,13 +60,23 @@ know why; the Linux terms in it are covered in
   kind of memory gVisor holds sandboxes in; measured at the default 60:
   0 bytes reclaimed. This is the check that reads the live value.
 
-## Network containment
+## Network
 
+- **net.ipv4.ip_forward = 1** — off, bridge networking is dead and
+  every sandbox is cut from the network right now. This is the one
+  check where the live value can lie: dockerd re-enables forwarding at
+  every daemon start, masking a boot config that says 0 until the next
+  sysctl config replay switches it back off — so it also reads the
+  boot config, in systemd-sysctl's own application order, and *warns*
+  naming the file that would turn it off.
 - **cloud metadata firewall** — `DROP` rules in the `DOCKER-USER` chain
   for `169.254.0.0/16` and `100.100.100.200`; without them a sandbox
   can steal cloud credentials from the metadata service.
 - **firewall rules persisted** — *warn*: rules living only in memory
-  silently vanish on reboot.
+  silently vanish on reboot. Persistence is the
+  `dormice-metadata-firewall` systemd unit the installer writes; a
+  host persisted by an older install via `iptables-persistent` still
+  passes.
 
 ## Configuration
 


### PR DESCRIPTION
## What & why

Fixes the two remaining defects from the end-to-end install test — both cases of a step reaching beyond what is Dormice's to change on an operator's host. Directions were agreed on the issues before this PR.

**#4 — installing iptables-persistent silently apt-removes ufw.** The metadata-firewall step now persists its two DROP rules with its own oneshot unit, `dormice-metadata-firewall.service` (`After=`/`Requires=docker.service`, `Before=dormice.service`, idempotent `iptables -C || iptables -I`), and stops installing `iptables-persistent` entirely. Beyond the ufw conflict, `netfilter-persistent save` always snapshotted the whole ruleset — operator rules and Docker's ephemeral NAT entries included — when exactly two rules are ours to persist. The unit is started at install time too: a unit that has never run is an unproven promise. Hosts persisted the old way keep their `rules.v4` untouched; doctor's `metadata-persisted` check accepts either form.

**#5 — `sysctl --system` replays operator config mid-install.** The sysctl step (now "kernel parameters") applies scoped with `sysctl -p /etc/sysctl.d/99-dormice.conf` and proves boot-order effectiveness explicitly instead: `systemd-sysctl --cat-config` gives the real application order, and the **winning value** of each key must be the one we need — dying loudly with the offending file and value otherwise. Value, not file: a host may legitimately set `ip_forward=1` in its own later-sorting config (the real test host does, via its VPN relay configs), and that is agreement, not a conflict. The scan also catches the `/etc/sysctl.conf`-via-`99-sysctl.conf` symlink that always outsorts `99-dormice.conf`, which the old filename-sorting assumption missed. The file gains `net.ipv4.ip_forward=1`: dockerd only masks a boot config that says 0, so the hazard stays invisible until the next config replay cuts every sandbox's networking — exactly how the test install failed. A new `ip-forward` doctor check fails on effective 0 (sandboxes are cut right now) and warns, naming the file, when the boot winner is 0 behind an effective 1; it is the one check allowed to read boot config, because the effective value can never expose this hazard.

Closes #4. Closes #5.

## Checklist

- [x] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` passes locally (build first — the e2e suite runs the built daemon)
- [x] Behavior changes come with tests that fail without the change
- [x] User-facing changes to `@dormice/shared` / `sdk` / `cli` have a changeset (`pnpm changeset`)
- [x] README updated if this changes documented behavior (README needed no change — it names no persistence mechanism; `docs/doctor` on the website is updated)

Real-machine acceptance on the test host (from-scratch reinstall + loud-die negative test + reboot) in progress — results will be posted below before merge.