### PR TITLE
Metadata firewall: the unit becomes the proven single rule-writer, and doctor certifies only what it verifies

### DIFF
--- a/.changeset/witty-badgers-guard.md
+++ b/.changeset/witty-badgers-guard.md
@@ -1,0 +1,5 @@
+---
+'@dormice/cli': patch
+---
+
+`dor doctor`'s firewall-persistence check now believes only what it can verify: `systemctl is-enabled` must say exactly `enabled` (exit 0 alone also covers `enabled-runtime`, `static`, `alias` and `generated`, none of which re-add the rules at the next boot), the `dormice-metadata-firewall` unit file must still drop both metadata targets, and the unit's last run must have succeeded — each failure mode gets its own warning naming what broke. Hosts persisted the pre-unit way via `iptables-persistent` still pass. Alongside, install.sh's unit now waits for the xtables lock (`iptables -w 10`), so losing the boot-time lock race against dockerd can no longer silently drop the metadata firewall.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -326,26 +326,26 @@ note 'verified: the sysctl boot order ends with our values for both keys'
 # curl to the metadata service steals live credentials. gVisor blocks kernel
 # attack surface, not network reachability — this must be firewalled.
 log 'cloud metadata firewall (DOCKER-USER chain)'
-docker_user=$(iptables -S DOCKER-USER 2>/dev/null) \
+iptables -w 10 -S DOCKER-USER >/dev/null 2>&1 \
   || die 'the DOCKER-USER chain is missing — is dockerd running?'
-added=''
-for target in 169.254.0.0/16 100.100.100.200; do
-  if ! printf '%s\n' "$docker_user" | grep -q -- "-d ${target%/*}\(/[0-9]*\)\? .*-j DROP"; then
-    iptables -I DOCKER-USER -d "$target" -j DROP
-    added="$added $target"
-  fi
-done
-if [ -n "$added" ]; then note "added DROP rules:$added"; else note '[skip] both DROP rules present'; fi
-# Persistence is our own oneshot unit that re-adds the rules after docker
-# creates the DOCKER-USER chain at boot (docker never flushes that chain
-# afterwards). Deliberately NOT iptables-persistent: installing it makes apt
+# One list, one writer: the oneshot unit below is the only mechanism that
+# inserts the rules — after docker creates the DOCKER-USER chain at boot
+# (docker never flushes that chain afterwards), and right here via the
+# restart. Deliberately NOT iptables-persistent: installing it makes apt
 # remove ufw (the packages conflict) — silently discarding an operator's
 # firewall — and `netfilter-persistent save` snapshots the whole ruleset,
 # operator rules and Docker's ephemeral NAT entries included, when exactly
 # two rules are ours to persist. Hosts persisted the old way keep their
 # /etc/iptables/rules.v4 untouched; the -C checks make duplicates impossible.
+# Every iptables call waits for the xtables lock (-w 10): at boot the unit
+# races dockerd for that lock, and without -w a lost race fails the unit
+# and silently leaves the metadata service reachable.
+METADATA_TARGETS='169.254.0.0/16 100.100.100.200'
 FIREWALL_UNIT=/etc/systemd/system/dormice-metadata-firewall.service
-firewall_unit=$(cat <<'EOF'
+firewall_exec=$(for target in $METADATA_TARGETS; do
+  printf "ExecStart=/bin/sh -c 'iptables -w 10 -C DOCKER-USER -d %s -j DROP 2>/dev/null || iptables -w 10 -I DOCKER-USER -d %s -j DROP'\n" "$target" "$target"
+done)
+firewall_unit=$(cat <<EOF
 # Written by Dormice install.sh — rewritten on every run. Sandboxes run
 # untrusted code; these rules keep them away from the cloud metadata service.
 [Unit]
@@ -357,8 +357,7 @@ Before=dormice.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/sh -c 'iptables -C DOCKER-USER -d 169.254.0.0/16 -j DROP 2>/dev/null || iptables -I DOCKER-USER -d 169.254.0.0/16 -j DROP'
-ExecStart=/bin/sh -c 'iptables -C DOCKER-USER -d 100.100.100.200 -j DROP 2>/dev/null || iptables -I DOCKER-USER -d 100.100.100.200 -j DROP'
+$firewall_exec
 
 [Install]
 WantedBy=multi-user.target
@@ -371,10 +370,25 @@ else
   systemctl daemon-reload
   note "wrote $FIREWALL_UNIT (re-adds the rules after docker starts — survives reboot)"
 fi
-systemctl enable dormice-metadata-firewall >/dev/null 2>&1
-# Started now, not only at boot: a unit that has never run is an unproven
-# promise, and the start is a no-op when the rules are already in.
+systemctl -q enable dormice-metadata-firewall
+missing_before=''
+for target in $METADATA_TARGETS; do
+  iptables -w 10 -C DOCKER-USER -d "$target" -j DROP 2>/dev/null \
+    || missing_before="$missing_before $target"
+done
+# Restarted now, not only at boot: the unit is the only rule-writer, so this
+# restart IS the mechanism — a fresh install exercises the -C||-I insert
+# path (rules absent), a re-run the -C path, and -C keeps it idempotent.
 systemctl restart dormice-metadata-firewall
+for target in $METADATA_TARGETS; do
+  iptables -w 10 -C DOCKER-USER -d "$target" -j DROP 2>/dev/null \
+    || die "the unit ran but the rule for $target is absent — journalctl -u dormice-metadata-firewall has the story"
+done
+if [ -n "$missing_before" ]; then
+  note "the unit added DROP rules:$missing_before"
+else
+  note '[skip] both DROP rules were in place — the unit re-confirmed them'
+fi
 
 # ---- Dormice code -----------------------------------------------------------
 # Defined before the pull so the rollback in on_exit can always call it.

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -26,6 +26,15 @@ const IPTABLES_GOOD = [
   '-A DOCKER-USER -j RETURN',
 ].join('\n');
 
+const FIREWALL_UNIT_PATH =
+  '/etc/systemd/system/dormice-metadata-firewall.service';
+const FIREWALL_UNIT_GOOD = [
+  '[Service]',
+  'Type=oneshot',
+  "ExecStart=/bin/sh -c 'iptables -w 10 -C DOCKER-USER -d 169.254.0.0/16 -j DROP 2>/dev/null || iptables -w 10 -I DOCKER-USER -d 169.254.0.0/16 -j DROP'",
+  "ExecStart=/bin/sh -c 'iptables -w 10 -C DOCKER-USER -d 100.100.100.200 -j DROP 2>/dev/null || iptables -w 10 -I DOCKER-USER -d 100.100.100.200 -j DROP'",
+].join('\n');
+
 const DF_ROOMY =
   'Filesystem 1024-blocks Used Available Capacity Mounted on\n' +
   '/dev/vda3 200000000 50000000 150000000 25% /';
@@ -63,6 +72,7 @@ function fakeHost(
     '/proc/sys/vm/swappiness': '100\n',
     '/proc/sys/net/ipv4/ip_forward': '1\n',
     '/etc/iptables/rules.v4': IPTABLES_GOOD,
+    [FIREWALL_UNIT_PATH]: FIREWALL_UNIT_GOOD,
     '/etc/caddy/Caddyfile':
       '# Managed by Dormice — setIngress rewrites this file.\n\n:80 {\n\treverse_proxy 127.0.0.1:3676\n}\n',
     ...overrides.files,
@@ -74,6 +84,7 @@ function fakeHost(
     ),
     'iptables -S DOCKER-USER': ok(IPTABLES_GOOD),
     'systemctl is-enabled dormice-metadata-firewall': ok('enabled\n'),
+    'systemctl is-active dormice-metadata-firewall': ok('active\n'),
     '/usr/lib/systemd/systemd-sysctl --cat-config': ok(CAT_CONFIG_GOOD),
     [`docker image inspect ${IMAGE}`]: ok('[{}]'),
     'df -Pk /var/lib/dormice': ok(DF_ROOMY),
@@ -274,6 +285,57 @@ describe('metadata firewall', () => {
     expect(results['metadata-persisted']).toMatchObject({
       status: 'pass',
       detail: expect.stringContaining('rules.v4'),
+    });
+  });
+
+  it("is-enabled exiting 0 with 'enabled-runtime' is not persistence", async () => {
+    // is-enabled exits 0 for enabled-runtime, static, alias and generated
+    // too — none of which start this unit at the next boot.
+    const { results, failed } = await runDoctor(
+      fakeHost({
+        files: { '/etc/iptables/rules.v4': undefined },
+        commands: {
+          'systemctl is-enabled dormice-metadata-firewall':
+            ok('enabled-runtime\n'),
+        },
+      }),
+    );
+    expect(results['metadata-persisted']).toMatchObject({
+      status: 'warn',
+      detail: expect.stringContaining('enabled-runtime'),
+      fix: expect.stringContaining('install.sh'),
+    });
+    expect(failed).toBe(false);
+  });
+
+  it('an enabled unit whose file lost a DROP target warns and names it', async () => {
+    const { results } = await runDoctor(
+      fakeHost({
+        files: {
+          [FIREWALL_UNIT_PATH]:
+            "[Service]\nExecStart=/bin/sh -c 'iptables -w 10 -C DOCKER-USER -d 169.254.0.0/16 -j DROP 2>/dev/null || iptables -w 10 -I DOCKER-USER -d 169.254.0.0/16 -j DROP'",
+        },
+      }),
+    );
+    expect(results['metadata-persisted']).toMatchObject({
+      status: 'warn',
+      detail: expect.stringContaining('100.100.100.200'),
+      fix: expect.stringContaining('install.sh'),
+    });
+  });
+
+  it('an enabled unit whose last run failed warns — boot may come up bare', async () => {
+    const { results } = await runDoctor(
+      fakeHost({
+        commands: {
+          'systemctl is-active dormice-metadata-firewall': boom('failed'),
+        },
+      }),
+    );
+    expect(results['metadata-persisted']).toMatchObject({
+      status: 'warn',
+      detail: expect.stringContaining('last run failed'),
+      fix: expect.stringContaining('install.sh'),
     });
   });
 });

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -110,6 +110,7 @@ const skip = (detail: string): CheckResult => ({ status: 'skip', detail });
 
 const DAEMON_JSON = '/etc/docker/daemon.json';
 const RULES_V4 = '/etc/iptables/rules.v4';
+const FIREWALL_UNIT = '/etc/systemd/system/dormice-metadata-firewall.service';
 const METADATA_IP = '100.100.100.200';
 const METADATA_RANGE = '169.254.0.0/16';
 const SYSCTL_FILE = '/etc/sysctl.d/99-dormice.conf';
@@ -393,11 +394,42 @@ const CHECKS: DoctorCheck[] = [
     title: 'firewall rules persisted',
     needs: ['metadata-firewall'],
     run: async (ctx) => {
-      const unit = await ctx.run('systemctl', [
+      const enabled = await ctx.run('systemctl', [
         'is-enabled',
         'dormice-metadata-firewall',
       ]);
-      if (unit.ok) {
+      // Exit 0 alone is not the fact we need: is-enabled also exits 0 for
+      // enabled-runtime, static, alias and generated — states that do not
+      // start this unit at the next boot. Only the word "enabled" does.
+      if (enabled.stdout.trim() === 'enabled') {
+        const unitText = await ctx.readTextFile(FIREWALL_UNIT);
+        const missingTargets = [METADATA_RANGE, METADATA_IP].filter(
+          (target) => !unitText?.includes(target),
+        );
+        if (unitText === undefined) {
+          return warn(
+            `the unit is enabled but ${FIREWALL_UNIT} is missing or unreadable — what it re-adds at boot cannot be verified`,
+            're-run install.sh (it rewrites the dormice-metadata-firewall systemd unit)',
+          );
+        }
+        if (missingTargets.length > 0) {
+          return warn(
+            `the unit is enabled but ${FIREWALL_UNIT} does not drop ${missingTargets.join(' or ')} — the next boot re-adds an incomplete firewall`,
+            're-run install.sh (it rewrites the dormice-metadata-firewall systemd unit)',
+          );
+        }
+        // A failed last run means the boot-time insert path is broken —
+        // the rules present now came from install time, not from the unit.
+        const active = await ctx.run('systemctl', [
+          'is-active',
+          'dormice-metadata-firewall',
+        ]);
+        if (!active.ok) {
+          return warn(
+            'the unit is enabled but its last run failed — the next boot may come up without the rules',
+            're-run install.sh (`journalctl -u dormice-metadata-firewall` has why the run failed)',
+          );
+        }
         return pass(
           'dormice-metadata-firewall.service re-adds the rules after docker starts',
         );
@@ -407,6 +439,12 @@ const CHECKS: DoctorCheck[] = [
       const rules = await ctx.readTextFile(RULES_V4);
       if (rules?.includes(METADATA_IP) && rules.includes('169.254')) {
         return pass(`both rules in ${RULES_V4} (iptables-persistent)`);
+      }
+      if (enabled.ok) {
+        return warn(
+          `systemctl calls the unit "${enabled.stdout.trim()}", not "enabled" — that state does not re-add the rules at the next boot`,
+          're-run install.sh (it enables the dormice-metadata-firewall systemd unit)',
+        );
       }
       return warn(
         'the DROP rules live only in memory — a reboot silently drops them',


### PR DESCRIPTION
## What & why

Fixes the three defects from #8 — the metadata-firewall unit could fail silently at exactly the moment it exists for, and doctor couldn't tell. Direction was agreed on the issue.

**The unit becomes the proven single rule-writer.** The inline `iptables -I` pre-insert loop is gone: the oneshot unit is now the only mechanism that inserts the DROP rules, at boot and at install time alike. That makes the install-time `systemctl restart` an actual proof — a fresh install exercises the real `-C || -I` insert path (rules absent), a re-run the `-C` path — where before, the pre-inserted rules guaranteed the unit's insert half was *never* exercised until the first real boot, which is precisely the "unproven promise" the restart was supposed to prevent. After the restart, install.sh asserts both rules with `iptables -C` and dies naming the target if the unit didn't deliver. Both ExecStart lines and the assertion loop are generated from one `METADATA_TARGETS` list — the endpoint set previously lived in three places, and a target added to one of them would have protected the live host but not reboots.

**Every iptables call waits for the xtables lock (`-w 10`).** `After=docker.service` schedules the unit at the moment dockerd is busiest programming iptables; on an iptables-legacy host a lost lock race made both `-C` and `-I` exit 4 immediately, failing the unit with no `Restart=` — and `Before=dormice.service` is ordering-only, so the daemon started anyway, sandboxes reachable to the metadata service. (`systemctl enable` also loses its `2>&1` gag: under `set -e` a failure there used to kill the install with no diagnostics.)

**Doctor certifies only what it verifies.** `is-enabled` exit 0 also covers `enabled-runtime`, `static`, `alias`, `generated` — states that do not start the unit at the next boot — and says nothing about whether the last run worked or the unit file still drops both targets. The `metadata-persisted` check now requires the word `enabled`, both targets present in the unit file, and a successful last run; each failure mode warns naming exactly what broke. Hosts persisted the pre-unit way via `iptables-persistent` still pass through the unchanged `rules.v4` branch.

The three new doctor tests were each run against the previous check and fail there — every one catches a real false-pass (enabled-runtime, missing target, failed last run).

Real-machine acceptance (fresh install + reboot on the test host, proving the unit under a genuine boot) has **not** been run from this change yet — recommended before merge, same drill as #7.

Closes #8.

## Checklist

- [x] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` passes locally (build first — the e2e suite runs the built daemon)
- [x] Behavior changes come with tests that fail without the change (all three red-verified against the old check)
- [x] User-facing changes to `@dormice/shared` / `sdk` / `cli` have a changeset (`pnpm changeset`)
- [x] README updated if this changes documented behavior (README names no persistence mechanism; the website doctor page's wording still holds)
