### PR TITLE
sysctl verification learns the second replay order, and its two parsers now agree

### DIFF
--- a/.changeset/lucid-geese-verify.md
+++ b/.changeset/lucid-geese-verify.md
@@ -1,0 +1,5 @@
+---
+'@dormice/cli': patch
+---
+
+`dor doctor`'s sysctl checks now verify both orders that can replay the boot config: systemd-sysctl's boot order, and procps `sysctl --system`, which applies `/etc/sysctl.conf` last — even without the 99-sysctl.conf symlink. The `--cat-config` parser no longer mistakes comments that merely start with `# /` for file markers (the stock sysctl.conf header is one, so a warning could blame a comment instead of the real file), recognizes the `- key = value` ignore-error form, tolerates CRLF line endings, and probes /lib/systemd like install.sh does; an unreadable boot config is a warn now, not a silent pass — that hazard is exactly the one the live value cannot expose. `vm.swappiness` gains the same boot-order coverage: 100 now with a boot config saying otherwise warns naming the file.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -285,11 +285,14 @@ fi
 # network. The file is named to sort after cloud-vendor sysctl.d files that
 # ship swappiness=0. Applied scoped — `sysctl --system` here would replay
 # every operator setting mid-install (an ip_forward=0 in /etc/sysctl.conf did
-# exactly that and killed the base-image build two steps later). Boot-order
-# effectiveness is verified against systemd-sysctl's own application order:
-# the winning value of each key must be the one we need. The value, not the
-# file — a host may legitimately set ip_forward=1 in its own later-sorting
-# config (the test host does), and that is agreement, not a conflict.
+# exactly that and killed the base-image build two steps later). Two replays
+# can overwrite these keys later, and both are verified: systemd-sysctl's
+# boot order (a global sort across the sysctl.d dirs, last setter wins), and
+# procps `sysctl --system`, which reads /etc/sysctl.conf LAST — even without
+# the 99-sysctl.conf symlink. In each order the winning value of every key
+# must be the one we need. The value, not the file — a host may legitimately
+# set ip_forward=1 in its own later-sorting config (the test host does), and
+# that is agreement, not a conflict.
 log 'kernel parameters (vm.swappiness = 100, net.ipv4.ip_forward = 1)'
 SYSCTL_FILE=/etc/sysctl.d/99-dormice.conf
 sysctl_wanted='# Managed by Dormice install.sh — rewritten on every run.
@@ -306,20 +309,48 @@ systemd_sysctl=/usr/lib/systemd/systemd-sysctl
 [ -x "$systemd_sysctl" ] || systemd_sysctl=/lib/systemd/systemd-sysctl
 [ -x "$systemd_sysctl" ] \
   || die 'cannot find systemd-sysctl to verify the sysctl boot order — non-systemd hosts are not supported'
-for kv in vm.swappiness=100 net.ipv4.ip_forward=1; do
-  key=${kv%%=*} want=${kv#*=}
-  winner=$("$systemd_sysctl" --cat-config | awk -v key="$key" '
-    /^# \//       { file = $2; next }
-    /^[ \t]*[#;]/ { next }
+# Last setter of `$1` in a sysctl config stream (stdin, or the file `$2`),
+# printed as
+# `file|value`. A file marker is a comment that IS a path and nothing else
+# (`# /path`) — `--cat-config` emits one before each file's lines; a comment
+# merely starting with `# /` (the stock sysctl.conf header is one) is
+# skipped like any other; `$2`, when given, is a marker-less file to read
+# and the name to report for it. Keys
+# tolerate the `- key` ignore-error form and `/` as the separator; values
+# keep internal whitespace and shed CRLF. Kept in sync by hand with
+# sysctlBootWinner in packages/cli/src/doctor.ts.
+sysctl_winner() {
+  awk -v key="$1" -v file="${2:-unknown}" '
+    /^# \// && NF == 2 { file = $2; next }
+    /^[ \t\r]*[#;]/    { next }
     {
       eq = index($0, "="); if (eq == 0) next
-      k = substr($0, 1, eq - 1); gsub(/[ \t]/, "", k); sub(/^-/, "", k); gsub("/", ".", k)
-      if (k == key) { v = substr($0, eq + 1); gsub(/[ \t]/, "", v); print file " " v }
-    }' | tail -n 1)
-  [ "${winner#* }" = "$want" ] \
-    || die "$key must be $want at boot, but the sysctl boot order ends with ${winner% *} setting it to ${winner#* } — change or remove that line, then re-run"
+      k = substr($0, 1, eq - 1); gsub(/[ \t\r]/, "", k); sub(/^-/, "", k); gsub("/", ".", k)
+      if (k != key) next
+      v = substr($0, eq + 1); sub(/^[ \t\r]+/, "", v); sub(/[ \t\r]+$/, "", v)
+      print file "|" v
+    }' ${2:+"$2"} | tail -n 1
+}
+cat_config=$("$systemd_sysctl" --cat-config)
+for kv in $(printf '%s\n' "$sysctl_wanted" | grep -v '^#'); do
+  key=${kv%%=*} want=${kv#*=}
+  winner=$(printf '%s\n' "$cat_config" | sysctl_winner "$key")
+  [ -n "$winner" ] \
+    || die "could not find $key anywhere in systemd-sysctl --cat-config output — expected at least $SYSCTL_FILE to appear; parse failure"
+  [ "${winner#*|}" = "$want" ] \
+    || die "$key must be $want at boot, but the sysctl boot order ends with ${winner%%|*} setting it to ${winner#*|} — change or remove that line, then re-run"
+  # procps `sysctl --system` (other installers run it) applies
+  # /etc/sysctl.conf after every sysctl.d file, symlink or not — a
+  # disagreeing value there overrides us at the very next replay even when
+  # the systemd boot order ends with ours.
+  if [ -f /etc/sysctl.conf ]; then
+    conf_value=$(sysctl_winner "$key" /etc/sysctl.conf)
+    conf_value=${conf_value#*|}
+    [ -z "$conf_value" ] || [ "$conf_value" = "$want" ] \
+      || die "$key must be $want, but /etc/sysctl.conf sets it to $conf_value — procps sysctl --system applies that file last, so the next config replay overrides us; change or remove that line, then re-run"
+  fi
 done
-note 'verified: the sysctl boot order ends with our values for both keys'
+note 'verified: both keys survive the sysctl boot order and a procps sysctl --system replay'
 
 # ---- cloud metadata firewall -------------------------------------------------
 # Sandboxes run untrusted code; on a cloud host with an attached role, one

--- a/packages/cli/src/doctor.test.ts
+++ b/packages/cli/src/doctor.test.ts
@@ -62,6 +62,11 @@ function fakeHost(
     '/proc/meminfo': 'MemTotal: 30000000 kB\nSwapTotal: 16777212 kB',
     '/proc/sys/vm/swappiness': '100\n',
     '/proc/sys/net/ipv4/ip_forward': '1\n',
+    // The stock Debian/Ubuntu file: a header comment that starts with
+    // `# /` but is not a file marker, and no keys. procps `sysctl
+    // --system` reads this file last; doctor checks it agrees.
+    '/etc/sysctl.conf':
+      '# /etc/sysctl.conf - Configuration file for setting system variables\n# See /etc/sysctl.d/ for additional settings\n',
     '/etc/iptables/rules.v4': IPTABLES_GOOD,
     '/etc/caddy/Caddyfile':
       '# Managed by Dormice — setIngress rewrites this file.\n\n:80 {\n\treverse_proxy 127.0.0.1:3676\n}\n',
@@ -201,6 +206,31 @@ describe('freezing prerequisites', () => {
       detail: expect.stringContaining('nowhere to push'),
     });
   });
+
+  it('effective 100 with a later boot file saying 0 warns and names the file', async () => {
+    // 100 right now, but a cloud vendor's file sorting after ours takes it
+    // back at the next reboot — the live value alone cannot see this yet.
+    const { results, failed } = await runDoctor(
+      fakeHost({
+        commands: {
+          '/usr/lib/systemd/systemd-sysctl --cat-config': ok(
+            [
+              '# /etc/sysctl.d/99-dormice.conf',
+              'vm.swappiness=100',
+              'net.ipv4.ip_forward=1',
+              '# /etc/sysctl.d/zz-cloud.conf',
+              'vm.swappiness = 0',
+            ].join('\n'),
+          ),
+        },
+      }),
+    );
+    expect(failed).toBe(false);
+    expect(results.swappiness).toMatchObject({
+      status: 'warn',
+      detail: expect.stringContaining('zz-cloud.conf sets 0 at boot'),
+    });
+  });
 });
 
 describe('docker configuration', () => {
@@ -329,6 +359,118 @@ describe('sandbox networking (net.ipv4.ip_forward)', () => {
       status: 'pass',
       detail: expect.stringContaining('dockerd re-enables'),
     });
+  });
+
+  it('a comment starting with "# /" is not a file marker — the warn names the real file', async () => {
+    // Stock /etc/sysctl.conf opens with `# /etc/sysctl.conf - Configuration
+    // file ...`, and --cat-config inlines it under the Debian 99-sysctl.conf
+    // symlink marker. A parser that takes any `# /` comment for a marker
+    // attributes the conflict to the comment text.
+    const { results } = await runDoctor(
+      fakeHost({
+        commands: {
+          '/usr/lib/systemd/systemd-sysctl --cat-config': ok(
+            [
+              '# /etc/sysctl.d/99-dormice.conf',
+              'vm.swappiness=100',
+              'net.ipv4.ip_forward=1',
+              '# /etc/sysctl.d/99-sysctl.conf',
+              '# /etc/sysctl.conf - Configuration file for setting system variables',
+              'net.ipv4.ip_forward = 0',
+            ].join('\n'),
+          ),
+        },
+      }),
+    );
+    expect(results['ip-forward']).toMatchObject({
+      status: 'warn',
+      detail: expect.stringContaining('/etc/sysctl.d/99-sysctl.conf sets 0'),
+    });
+  });
+
+  it('the "- key = value" ignore-error form is a setter like any other', async () => {
+    const { results } = await runDoctor(
+      fakeHost({
+        commands: {
+          '/usr/lib/systemd/systemd-sysctl --cat-config': ok(
+            [
+              '# /etc/sysctl.d/99-dormice.conf',
+              'vm.swappiness=100',
+              'net.ipv4.ip_forward=1',
+              '# /etc/sysctl.d/zz-operator.conf',
+              '- net.ipv4.ip_forward = 0',
+            ].join('\n'),
+          ),
+        },
+      }),
+    );
+    expect(results['ip-forward']).toMatchObject({
+      status: 'warn',
+      detail: expect.stringContaining('zz-operator.conf sets 0'),
+    });
+  });
+
+  it('an /etc/sysctl.conf that disagrees warns — procps sysctl --system applies it last', async () => {
+    // The systemd boot order ends with our 1, but procps replays
+    // /etc/sysctl.conf after every sysctl.d file, symlink or not.
+    const { results, failed } = await runDoctor(
+      fakeHost({ files: { '/etc/sysctl.conf': 'net.ipv4.ip_forward = 0\n' } }),
+    );
+    expect(failed).toBe(false);
+    expect(results['ip-forward']).toMatchObject({
+      status: 'warn',
+      detail: expect.stringContaining('/etc/sysctl.conf sets 0'),
+    });
+    expect(results['ip-forward']?.detail).toContain('applies that file last');
+  });
+
+  it('an unverifiable boot config warns — the live value cannot expose this hazard', async () => {
+    // Both probe paths fail (the fake answers nothing for /lib either).
+    const { results, failed } = await runDoctor(
+      fakeHost({
+        commands: {
+          '/usr/lib/systemd/systemd-sysctl --cat-config': boom(
+            'No such file or directory',
+          ),
+        },
+      }),
+    );
+    expect(failed).toBe(false);
+    expect(results['ip-forward']).toMatchObject({
+      status: 'warn',
+      detail: expect.stringContaining('/lib/systemd/systemd-sysctl'),
+    });
+    // swappiness keeps passing on its live value: swappiness drift
+    // surfaces there after a reboot; ip_forward's never does.
+    expect(statusOf(results, 'swappiness')).toBe('pass');
+  });
+
+  it('falls back to /lib/systemd/systemd-sysctl when /usr/lib has no binary', async () => {
+    const { results } = await runDoctor(
+      fakeHost({
+        commands: {
+          '/usr/lib/systemd/systemd-sysctl --cat-config': boom(
+            'No such file or directory',
+          ),
+          '/lib/systemd/systemd-sysctl --cat-config': ok(CAT_CONFIG_GOOD),
+        },
+      }),
+    );
+    expect(results['ip-forward']).toMatchObject({
+      status: 'pass',
+      detail: expect.stringContaining(
+        'persisted by /etc/sysctl.d/99-dormice.conf',
+      ),
+    });
+  });
+
+  it('a CRLF config line agreeing with us is agreement, not a conflict', async () => {
+    // An /etc/sysctl.conf written on Windows: the naive read of the value
+    // is "1\r", which is not "1".
+    const { results } = await runDoctor(
+      fakeHost({ files: { '/etc/sysctl.conf': 'net.ipv4.ip_forward=1\r\n' } }),
+    );
+    expect(results['ip-forward']).toMatchObject({ status: 'pass' });
   });
 });
 

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -113,32 +113,87 @@ const RULES_V4 = '/etc/iptables/rules.v4';
 const METADATA_IP = '100.100.100.200';
 const METADATA_RANGE = '169.254.0.0/16';
 const SYSCTL_FILE = '/etc/sysctl.d/99-dormice.conf';
-// Not on PATH; /lib is merged into /usr/lib on every supported target.
-const SYSTEMD_SYSCTL = '/usr/lib/systemd/systemd-sysctl';
+// Not on PATH; same probe as install.sh — /usr/lib first, then /lib for
+// hosts without a merged /usr.
+const SYSTEMD_SYSCTL_PATHS = [
+  '/usr/lib/systemd/systemd-sysctl',
+  '/lib/systemd/systemd-sysctl',
+];
 
 /**
- * The file whose value for `key` wins at boot, parsed from
- * `systemd-sysctl --cat-config` — the authoritative application order,
- * with `# /path` lines marking each file. Last setter wins.
+ * The file whose value for `key` wins when `content` is replayed in
+ * order — last setter wins. `systemd-sysctl --cat-config` opens each file
+ * with a `# /path` marker: a comment that IS a path and nothing else; a
+ * comment merely starting with `# /` (the stock sysctl.conf header is one)
+ * is skipped like any other. Plain /etc/sysctl.conf content carries no
+ * markers, so callers name it via `initialFile`. Kept in sync by hand with
+ * the awk program in deploy/install.sh.
  */
 function sysctlBootWinner(
-  catConfig: string,
+  content: string,
   key: string,
+  initialFile = 'unknown',
 ): { file: string; value: string } | undefined {
-  let file = 'unknown';
+  let file = initialFile;
   let winner: { file: string; value: string } | undefined;
-  for (const line of catConfig.split('\n')) {
-    if (line.startsWith('# /')) {
-      file = line.slice(2).trim();
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    if (/^# \/\S+$/.test(line)) {
+      file = line.slice(2);
       continue;
     }
     if (/^\s*[#;]/.test(line)) continue;
     const eq = line.indexOf('=');
     if (eq < 0) continue;
-    const k = line.slice(0, eq).trim().replace(/^-/, '').replaceAll('/', '.');
+    const k = line
+      .slice(0, eq)
+      .replace(/\s+/g, '')
+      .replace(/^-/, '')
+      .replaceAll('/', '.');
     if (k === key) winner = { file, value: line.slice(eq + 1).trim() };
   }
   return winner;
+}
+
+/**
+ * Two replays can overwrite a sysctl after install.sh sets it:
+ * systemd-sysctl at boot (a global sort across the sysctl.d dirs), and
+ * procps `sysctl --system`, which reads /etc/sysctl.conf LAST — even
+ * without the Debian 99-sysctl.conf symlink. Both must end with the wanted
+ * value. Judged by value, not file: an operator file that sets the same
+ * value is agreement, not a conflict.
+ */
+async function sysctlReplayVerdict(
+  ctx: DoctorContext,
+  key: string,
+  want: string,
+): Promise<
+  | { kind: 'unreadable' }
+  | { kind: 'conflict'; file: string; value: string; order: 'boot' | 'procps' }
+  | { kind: 'agrees'; file?: string }
+> {
+  let catConfig: string | undefined;
+  for (const path of SYSTEMD_SYSCTL_PATHS) {
+    const res = await ctx.run(path, ['--cat-config']);
+    if (res.ok) {
+      catConfig = res.stdout;
+      break;
+    }
+  }
+  if (catConfig === undefined) return { kind: 'unreadable' };
+  const boot = sysctlBootWinner(catConfig, key);
+  if (boot !== undefined && boot.value !== want) {
+    return { kind: 'conflict', ...boot, order: 'boot' };
+  }
+  const conf = await ctx.readTextFile('/etc/sysctl.conf');
+  const last =
+    conf === undefined
+      ? undefined
+      : sysctlBootWinner(conf, key, '/etc/sysctl.conf');
+  if (last !== undefined && last.value !== want) {
+    return { kind: 'conflict', ...last, order: 'procps' };
+  }
+  return { kind: 'agrees', file: boot?.file };
 }
 
 async function daemonJson(
@@ -307,18 +362,31 @@ const CHECKS: DoctorCheck[] = [
     title: 'vm.swappiness = 100',
     needs: ['os-linux'],
     run: async (ctx) => {
-      // The live value, on purpose: some clouds ship swappiness=0 in their
-      // own sysctl.d file, so a config file existing proves nothing.
+      // The live value first, on purpose: some clouds ship swappiness=0 in
+      // their own sysctl.d file, so a config file existing proves nothing.
       const raw = await ctx.readTextFile('/proc/sys/vm/swappiness');
       const value = raw?.trim();
       if (value === undefined)
         return fail('cannot read /proc/sys/vm/swappiness');
-      return value === '100'
-        ? pass('100 (effective value)')
-        : fail(
-            `effective value is ${value} — below 100 the kernel refuses to swap gVisor's shmem-held sandbox memory (measured at 60: 0 bytes reclaimed)`,
-            `re-run install.sh — it persists 100 in ${SYSCTL_FILE}, applies it scoped, and verifies nothing later in the sysctl boot order overrides it`,
-          );
+      if (value !== '100') {
+        return fail(
+          `effective value is ${value} — below 100 the kernel refuses to swap gVisor's shmem-held sandbox memory (measured at 60: 0 bytes reclaimed)`,
+          `re-run install.sh — it persists 100 in ${SYSCTL_FILE}, applies it scoped, and verifies nothing later in the sysctl boot order overrides it`,
+        );
+      }
+      const verdict = await sysctlReplayVerdict(ctx, 'vm.swappiness', '100');
+      if (verdict.kind === 'conflict') {
+        return warn(
+          verdict.order === 'boot'
+            ? `100 now, but ${verdict.file} sets ${verdict.value} at boot — after the next reboot, freezing reclaims nothing`
+            : `100 now, but ${verdict.file} sets ${verdict.value} — procps sysctl --system applies that file last, so the next config replay drops it and freezing reclaims nothing`,
+          `drop vm.swappiness from ${verdict.file}, or re-run install.sh and let it verify the boot order`,
+        );
+      }
+      // An unreadable boot config still passes here, unlike ip_forward:
+      // nothing masks swappiness drift — a boot config saying otherwise
+      // surfaces in this live value after the next reboot.
+      return pass('100 (effective value)');
     },
   },
   {
@@ -341,23 +409,31 @@ const CHECKS: DoctorCheck[] = [
       // other installer's `sysctl --system`) re-applies it and cuts sandbox
       // networking until dockerd restarts. Unlike swappiness, whose drift
       // surfaces in the effective value after a reboot, this one can stay
-      // masked forever — so this check alone also reads the boot config, in
-      // systemd-sysctl's own application order.
-      const res = await ctx.run(SYSTEMD_SYSCTL, ['--cat-config']);
-      if (!res.ok) {
-        return pass('1 (effective value; boot config unreadable here)');
-      }
-      const winner = sysctlBootWinner(res.stdout, 'net.ipv4.ip_forward');
-      if (winner !== undefined && winner.value !== '1') {
+      // masked forever — so this check alone reads the boot config in both
+      // orders that can replay it, and an unreadable boot config is a
+      // warn, not a pass: the live value cannot expose this hazard.
+      const verdict = await sysctlReplayVerdict(
+        ctx,
+        'net.ipv4.ip_forward',
+        '1',
+      );
+      if (verdict.kind === 'unreadable') {
         return warn(
-          `1 now, but ${winner.file} sets ${winner.value} at boot — the next sysctl config replay cuts every sandbox's networking`,
-          `drop net.ipv4.ip_forward from ${winner.file}, or re-run install.sh and let it verify the boot order`,
+          `1 now, but the boot config cannot be verified — systemd-sysctl --cat-config failed at both ${SYSTEMD_SYSCTL_PATHS.join(' and ')}; a boot config saying 0 stays masked by dockerd until the next sysctl replay cuts every sandbox's networking`,
+        );
+      }
+      if (verdict.kind === 'conflict') {
+        return warn(
+          verdict.order === 'boot'
+            ? `1 now, but ${verdict.file} sets ${verdict.value} at boot — the next sysctl config replay cuts every sandbox's networking`
+            : `1 now, but ${verdict.file} sets ${verdict.value} — procps sysctl --system applies that file last, so the next config replay cuts every sandbox's networking`,
+          `drop net.ipv4.ip_forward from ${verdict.file}, or re-run install.sh and let it verify the boot order`,
         );
       }
       return pass(
-        winner === undefined
+        verdict.file === undefined
           ? '1 (effective value; no boot config sets it — dockerd re-enables it at every start)'
-          : `1 (effective value, persisted by ${winner.file})`,
+          : `1 (effective value, persisted by ${verdict.file})`,
       );
     },
   },

--- a/website/content/docs/doctor.mdx
+++ b/website/content/docs/doctor.mdx
@@ -67,8 +67,10 @@ know why; the Linux terms in it are covered in
   check where the live value can lie: dockerd re-enables forwarding at
   every daemon start, masking a boot config that says 0 until the next
   sysctl config replay switches it back off — so it also reads the
-  boot config, in systemd-sysctl's own application order, and *warns*
-  naming the file that would turn it off.
+  boot config, in both orders that can replay it (systemd-sysctl's
+  boot order, and procps `sysctl --system`, which applies
+  `/etc/sysctl.conf` last), and *warns* naming the file that would
+  turn it off.
 - **cloud metadata firewall** — `DROP` rules in the `DOCKER-USER` chain
   for `169.254.0.0/16` and `100.100.100.200`; without them a sandbox
   can steal cloud credentials from the metadata service.


### PR DESCRIPTION
## What & why

Fixes the four defects from #9. Direction was agreed on the issue; the guiding principle from #7's acceptance — judge by **value, not file** — survives everywhere.

**The verification learns the second replay order.** The hazard both the install step and the doctor check name is a procps `sysctl --system` replay — and procps applies `/etc/sysctl.conf` **last**, after every sysctl.d directory, symlink or no symlink. The old check only computed the winner under systemd-sysctl's global filename sort, so the exact incident #5 was about could still pass green (a masked `ip_forward=0` in `/etc/sysctl.conf` behind an agreeing later-sorting sysctl.d file — or behind a removed `99-sysctl.conf` symlink). Both install.sh and doctor now verify the systemd-order winner *and* read `/etc/sysctl.conf` directly: a disagreeing value there dies (install) / warns (doctor) naming the file and which replay bites. An agreeing value anywhere remains agreement, not a conflict.

**The two `--cat-config` parsers now agree, and are right.** One semantics, mirrored in the awk program and `sysctlBootWinner`, each carrying a kept-in-sync-by-hand pointer at the other. A file marker is a comment that IS a path and nothing else — the stock Debian/Ubuntu `/etc/sysctl.conf` header ("# /etc/sysctl.conf - Configuration file …") is no longer eaten as a marker, so warnings blame the real file instead of a comment fragment. The `- key = value` ignore-error form is a setter in both parsers (the TS used to trim before stripping `-` and never matched it). CRLF is shed everywhere (the awk used to die "must be 1 … setting it to 1" on a host that genuinely boots to 1). Values keep their internal whitespace, and an empty awk match is now an explicit parse-failure die instead of the garbled "ends with  setting it to ".

**Doctor probes both binaries and stops passing on silence.** `/usr/lib/systemd/systemd-sysctl` then `/lib/systemd/systemd-sysctl` — the same probe install.sh already had; the old const contradicted it in the same commit. And an unreadable boot config is now a *warn* for ip_forward, not a pass: this is the one hazard the live value can never expose, so "couldn't look" must not read as "looked and found nothing". Swappiness keeps passing on the live value when the boot config is unreadable — its drift honestly surfaces in `/proc` after the next reboot — but gains the same boot-order coverage through the shared helper: 100 now with a boot config saying otherwise warns naming the file.

**One list.** install.sh's verify loop now derives its keys from the `sysctl_wanted` heredoc itself (and runs `--cat-config` once, not per key) — a parameter added to the file can no longer be applied yet silently unverified.

Six of the seven new doctor tests fail against the previous code (each catches a real defect); the seventh pins CRLF tolerance the TS side had only by accident. The awk program was validated empirically on BSD awk against the stock-header, ignore-error, CRLF, internal-whitespace, and no-match inputs, byte-extracted from the committed script.

Real-machine acceptance (fresh install + the #5 negative test replayed on the test host) has **not** been run from this change yet — recommended before merge, same drill as #7.

Closes #9.

## Checklist

- [x] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` passes locally (build first — the e2e suite runs the built daemon)
- [x] Behavior changes come with tests that fail without the change (6/7 red-verified; the 7th is a deliberate regression guard)
- [x] User-facing changes to `@dormice/shared` / `sdk` / `cli` have a changeset (`pnpm changeset`)
- [x] README updated if this changes documented behavior (README doesn't cover the check's mechanics; the website doctor page's ip_forward bullet is updated to the dual-order wording in this PR)
