### PR TITLE
The doctor docs page gains its missing ingress (Caddy) bullet

### DIFF
--- a/website/content/docs/doctor.mdx
+++ b/website/content/docs/doctor.mdx
@@ -88,6 +88,15 @@ know why; the Linux terms in it are covered in
   a half-configured archiver anyway).
 - **zstd available** — the archiver shells out to `tar -I zstd` on the
   host at every archive and restore.
+- **ingress (Caddy)** — skipped when `DORMICE_INGRESS_FILE` is not
+  set: the daemon manages no reverse proxy, and you bind domains by
+  editing your proxy config directly. Set, the `caddy` binary must be
+  installed and the caddy service active — a missing binary means
+  `setIngress` cannot reload anything, and an inactive service means
+  nothing proxies the outside world to the daemon. A config file that
+  doesn't exist yet is a *warn* (the first bind creates it), and so is
+  one the daemon did not write: `setIngress` refuses to overwrite it,
+  so web domain binding is effectively off.
 - **base image available** — present locally; the fix names
   `images/Dockerfile`, and doctor never pulls.
 - **docker-mode paths absolute** — a relative `DORMICE_DB_PATH` depends


### PR DESCRIPTION
## What & why

Fixes #10. The doctor page promises "The list below explains what each check is protecting" and delivered on every check except **ingress (Caddy)** — an operator who sets `DORMICE_INGRESS_FILE`, gets a fail, and opens the page found nothing to search for.

One bullet, in the Configuration section (mirroring the check's position in source order, next to its fellow env-var-gated S3 neighbor), with every claim traced to the check's implementation — the honest skip when the variable is unset, the caddy-binary and service-active requirements, and the *warn* cases: a config file that doesn't exist yet (the first bind creates it) and one the daemon did not write, which `setIngress` refuses to overwrite. No check count is stated anywhere, per the page's existing discipline.

Verified by building the website: the static export renders the bullet on `docs/doctor` and into `llms-full.txt`.

Closes #10.

## Checklist

- [x] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` passes locally (build first — the e2e suite runs the built daemon)
- [x] Behavior changes come with tests that fail without the change (docs-only — no behavior change)
- [x] User-facing changes to `@dormice/shared` / `sdk` / `cli` have a changeset (`pnpm changeset`) (none touched — website is not published)
- [x] README updated if this changes documented behavior (README doesn't list doctor's checks)
