### PR TITLE
Make directory watcher cleanup single-owner

### DIFF
--- a/packages/console/src/features/sandboxes/hooks/directory-watcher.test.ts
+++ b/packages/console/src/features/sandboxes/hooks/directory-watcher.test.ts
@@ -110,8 +110,24 @@ describe('DirectoryWatcherController', () => {
       { name: 'queued.txt', type: 'EVENT_TYPE_CREATE' },
     ]);
     await t.controller.tick();
-    expect(t.onDirty).toHaveBeenCalledTimes(1);
+    expect(t.onDirty).toHaveBeenCalledWith(false);
     expect(t.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes once after a dirty frozen watcher becomes active again', async () => {
+    const t = harness();
+    await t.controller.tick();
+    t.setActive(false);
+    t.poll.mockResolvedValueOnce([
+      { name: 'queued.txt', type: 'EVENT_TYPE_CREATE' },
+    ]);
+    await t.controller.tick();
+
+    t.setActive(true);
+    await t.controller.tick();
+    await t.controller.tick();
+
+    expect(t.onDirty.mock.calls).toEqual([[false], [true]]);
   });
 
   it('rearms only after a confirmed not_found response', async () => {

--- a/packages/console/src/features/sandboxes/hooks/directory-watcher.test.ts
+++ b/packages/console/src/features/sandboxes/hooks/directory-watcher.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EnvdError, type EnvdWatchEvent } from '../envd-client';
+import {
+  DirectoryWatcherController,
+  type DirectoryWatcherDeps,
+} from './directory-watcher';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function harness(overrides: Partial<DirectoryWatcherDeps> = {}) {
+  const create = vi.fn<() => Promise<string>>().mockResolvedValue('watch-1');
+  const poll = vi
+    .fn<(id: string) => Promise<EnvdWatchEvent[]>>()
+    .mockResolvedValue([]);
+  const remove = vi.fn<(id: string) => Promise<void>>().mockResolvedValue();
+  const onDirty = vi.fn();
+  let active = true;
+  const controller = new DirectoryWatcherController({
+    create,
+    poll,
+    remove,
+    isActive: () => active,
+    isNotFound: (error) =>
+      error instanceof EnvdError && error.code === 'not_found',
+    onDirty,
+    ...overrides,
+  });
+  return {
+    controller,
+    create,
+    poll,
+    remove,
+    onDirty,
+    setActive(value: boolean) {
+      active = value;
+    },
+  };
+}
+
+describe('DirectoryWatcherController', () => {
+  it('removes the watcher exactly once after normal disposal', async () => {
+    const t = harness();
+    await t.controller.tick();
+    t.controller.dispose();
+    t.controller.dispose();
+    await vi.waitFor(() => expect(t.remove).toHaveBeenCalledWith('watch-1'));
+    expect(t.remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('retires an ID returned after disposal', async () => {
+    const pending = deferred<string>();
+    const t = harness({ create: () => pending.promise });
+    const tick = t.controller.tick();
+    t.controller.dispose();
+    pending.resolve('late');
+    await tick;
+    expect(t.remove).toHaveBeenCalledWith('late');
+  });
+
+  it('keeps create single-flight across repeated timer ticks', async () => {
+    const pending = deferred<string>();
+    const create = vi.fn(() => pending.promise);
+    const t = harness({ create });
+    const first = t.controller.tick();
+    const second = t.controller.tick();
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+    pending.resolve('slow');
+    await first;
+  });
+
+  it('does not arm while inactive and preserves an existing watcher through freeze', async () => {
+    const t = harness();
+    t.setActive(false);
+    await t.controller.tick();
+    expect(t.create).not.toHaveBeenCalled();
+
+    t.setActive(true);
+    await t.controller.tick();
+    t.setActive(false);
+    await t.controller.tick();
+    expect(t.poll).toHaveBeenCalledWith('watch-1');
+    expect(t.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains the watcher after a transient poll error', async () => {
+    const t = harness();
+    await t.controller.tick();
+    t.poll.mockRejectedValueOnce(new Error('temporary network failure'));
+    await t.controller.tick();
+    await t.controller.tick();
+    expect(t.poll).toHaveBeenCalledTimes(2);
+    expect(t.create).toHaveBeenCalledTimes(1);
+    expect(t.onDirty).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports events while frozen without creating another watcher', async () => {
+    const t = harness();
+    await t.controller.tick();
+    t.setActive(false);
+    t.poll.mockResolvedValueOnce([
+      { name: 'queued.txt', type: 'EVENT_TYPE_CREATE' },
+    ]);
+    await t.controller.tick();
+    expect(t.onDirty).toHaveBeenCalledTimes(1);
+    expect(t.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('rearms only after a confirmed not_found response', async () => {
+    const t = harness();
+    t.create.mockResolvedValueOnce('old').mockResolvedValueOnce('new');
+    await t.controller.tick();
+    t.poll.mockRejectedValueOnce(new EnvdError('gone', 'not_found', 404));
+    await t.controller.tick();
+    await t.controller.tick();
+    expect(t.create).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not invalidate or rearm after disposal during a poll', async () => {
+    const pending = deferred<EnvdWatchEvent[]>();
+    const t = harness({ poll: () => pending.promise });
+    await t.controller.tick();
+    const polling = t.controller.tick();
+    t.controller.dispose();
+    pending.resolve([{ name: 'late.txt', type: 'EVENT_TYPE_CREATE' }]);
+    await polling;
+    await t.controller.tick();
+    expect(t.onDirty).not.toHaveBeenCalled();
+    expect(t.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates rapid effect generations', async () => {
+    const oldCreate = deferred<string>();
+    const old = harness({ create: () => oldCreate.promise });
+    const oldTick = old.controller.tick();
+    old.controller.dispose();
+
+    const next = harness({ create: async () => 'new' });
+    await next.controller.tick();
+    oldCreate.resolve('old');
+    await oldTick;
+
+    expect(old.remove).toHaveBeenCalledWith('old');
+    expect(next.remove).not.toHaveBeenCalled();
+  });
+});

--- a/packages/console/src/features/sandboxes/hooks/directory-watcher.ts
+++ b/packages/console/src/features/sandboxes/hooks/directory-watcher.ts
@@ -6,7 +6,7 @@ export interface DirectoryWatcherDeps {
   remove(watcherId: string): Promise<void>;
   isActive(): boolean;
   isNotFound(error: unknown): boolean;
-  onDirty(): void;
+  onDirty(active: boolean): void;
 }
 
 /**
@@ -17,12 +17,17 @@ export interface DirectoryWatcherDeps {
 export class DirectoryWatcherController {
   private watcherId: string | null = null;
   private disposed = false;
+  private inactiveDirty = false;
   private inFlight: Promise<void> | null = null;
 
   constructor(private readonly deps: DirectoryWatcherDeps) {}
 
   tick(): Promise<void> {
     if (this.disposed) return Promise.resolve();
+    if (this.deps.isActive() && this.inactiveDirty) {
+      this.inactiveDirty = false;
+      this.deps.onDirty(true);
+    }
     if (this.inFlight) return this.inFlight;
 
     const run = this.runTick();
@@ -61,7 +66,7 @@ export class DirectoryWatcherController {
     try {
       const events = await this.deps.poll(current);
       if (!this.disposed && this.watcherId === current && events.length > 0) {
-        this.deps.onDirty();
+        this.reportDirty();
       }
     } catch (error) {
       if (this.deps.isNotFound(error) && this.watcherId === current) {
@@ -69,9 +74,15 @@ export class DirectoryWatcherController {
       } else if (!this.disposed && this.watcherId === current) {
         // Drain is destructive at the daemon. A lost response may have eaten
         // events, so the directory must converge even though this ID remains.
-        this.deps.onDirty();
+        this.reportDirty();
       }
     }
+  }
+
+  private reportDirty(): void {
+    const active = this.deps.isActive();
+    if (!active) this.inactiveDirty = true;
+    this.deps.onDirty(active);
   }
 
   private takeWatcher(): string | null {

--- a/packages/console/src/features/sandboxes/hooks/directory-watcher.ts
+++ b/packages/console/src/features/sandboxes/hooks/directory-watcher.ts
@@ -1,0 +1,90 @@
+import type { EnvdWatchEvent } from '../envd-client';
+
+export interface DirectoryWatcherDeps {
+  create(): Promise<string>;
+  poll(watcherId: string): Promise<EnvdWatchEvent[]>;
+  remove(watcherId: string): Promise<void>;
+  isActive(): boolean;
+  isNotFound(error: unknown): boolean;
+  onDirty(): void;
+}
+
+/**
+ * One effect generation's ownership of one polling watcher. Every arm/poll
+ * goes through the same single-flight tick; dispose takes the published ID,
+ * while an ID still in flight is retired by the create continuation itself.
+ */
+export class DirectoryWatcherController {
+  private watcherId: string | null = null;
+  private disposed = false;
+  private inFlight: Promise<void> | null = null;
+
+  constructor(private readonly deps: DirectoryWatcherDeps) {}
+
+  tick(): Promise<void> {
+    if (this.disposed) return Promise.resolve();
+    if (this.inFlight) return this.inFlight;
+
+    const run = this.runTick();
+    this.inFlight = run;
+    void run.finally(() => {
+      if (this.inFlight === run) this.inFlight = null;
+    });
+    return run;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    const id = this.takeWatcher();
+    if (id) void this.release(id);
+  }
+
+  private async runTick(): Promise<void> {
+    const current = this.watcherId;
+    if (current === null) {
+      if (!this.deps.isActive()) return;
+      let created: string;
+      try {
+        created = await this.deps.create();
+      } catch {
+        return;
+      }
+      if (this.disposed) {
+        await this.release(created);
+        return;
+      }
+      this.watcherId = created;
+      return;
+    }
+
+    try {
+      const events = await this.deps.poll(current);
+      if (!this.disposed && this.watcherId === current && events.length > 0) {
+        this.deps.onDirty();
+      }
+    } catch (error) {
+      if (this.deps.isNotFound(error) && this.watcherId === current) {
+        this.watcherId = null;
+      } else if (!this.disposed && this.watcherId === current) {
+        // Drain is destructive at the daemon. A lost response may have eaten
+        // events, so the directory must converge even though this ID remains.
+        this.deps.onDirty();
+      }
+    }
+  }
+
+  private takeWatcher(): string | null {
+    const id = this.watcherId;
+    this.watcherId = null;
+    return id;
+  }
+
+  private async release(watcherId: string): Promise<void> {
+    try {
+      await this.deps.remove(watcherId);
+    } catch {
+      // Gone already is the cleanup goal; lifecycle races are expected here.
+    }
+  }
+}

--- a/packages/console/src/features/sandboxes/hooks/useEnvd.ts
+++ b/packages/console/src/features/sandboxes/hooks/useEnvd.ts
@@ -120,7 +120,19 @@ export function useDirectoryWatch(
 ) {
   const queryClient = useQueryClient();
   const activeRef = useRef(opts.active);
+  const previousActiveRef = useRef(opts.active);
   activeRef.current = opts.active;
+
+  useEffect(() => {
+    const wasActive = previousActiveRef.current;
+    previousActiveRef.current = opts.active;
+    if (!opts.enabled) return;
+    if (!wasActive && opts.active && auth) {
+      void queryClient.invalidateQueries({
+        queryKey: ['envdDir', auth.sandboxId, path],
+      });
+    }
+  }, [auth, opts.active, opts.enabled, path, queryClient]);
 
   useEffect(() => {
     if (!opts.enabled || !auth) return;

--- a/packages/console/src/features/sandboxes/hooks/useEnvd.ts
+++ b/packages/console/src/features/sandboxes/hooks/useEnvd.ts
@@ -124,12 +124,24 @@ export function useDirectoryWatch(
   useEffect(() => {
     if (!opts.enabled || !auth) return;
     let watcherId: string | null = null;
+    let disposed = false;
     let busy = false;
 
     const arm = async () => {
       if (!activeRef.current) return; // 冻结/停止:武装会唤醒,等真实使用
       try {
-        watcherId = await createWatcher(auth, path);
+        const id = await createWatcher(auth, path);
+        if (disposed) {
+          // effect 已在建监听的往返途中被拆(切目录或卸载);这个 id 归
+          // 属已死的闭包,同步 cleanup 那时读到的还是 null,拆不掉它 ——
+          // 在此补拆,别把 inotifywait 漏在容器里。active 闸同 cleanup:
+          // 沙箱睡了就留给容器随手回收。
+          if (activeRef.current) {
+            void removeWatcher(auth, id).catch(() => undefined);
+          }
+          return;
+        }
+        watcherId = id;
       } catch {
         watcherId = null; // 冷启动窗口或目录暂不可达;下一拍再试
       }
@@ -162,6 +174,7 @@ export function useDirectoryWatch(
     }, 2000);
 
     return () => {
+      disposed = true;
       clearInterval(timer);
       // 只有沙箱还醒着才顺手拆(RemoveWatcher 要容器活着);睡了就留给
       // 容器回收 — 一个 inotifywait 活不过下一次停止。

--- a/packages/console/src/features/sandboxes/hooks/useEnvd.ts
+++ b/packages/console/src/features/sandboxes/hooks/useEnvd.ts
@@ -5,6 +5,7 @@ import {
   createWatcher,
   downloadFile,
   type EnvdAuth,
+  EnvdError,
   getWatcherEvents,
   killProcess,
   listDir,
@@ -15,6 +16,7 @@ import {
   removeWatcher,
   uploadFile,
 } from '../envd-client';
+import { DirectoryWatcherController } from './directory-watcher';
 
 /**
  * 一个沙箱的 envd 面数据层:token、文件、进程。token 是无状态 HMAC,
@@ -106,11 +108,10 @@ export function useFileMutations(auth: EnvdAuth | undefined) {
  * → RemoveWatcher),沙箱里(agent、终端)动了文件,面板 2 秒内自己跟上。
  *
  * 唤醒纪律是这个 hook 的全部难点:GetWatcherEvents 不唤醒(读 daemon
- * 内存,冻结沙箱的盘也不会变),可以放心轮询;但 Create/Remove 都要容器
- * 活着(容器里有个 inotifywait 要起/停)— 所以**只在沙箱 active 时武装
- * 或拆除**。沙箱睡了就让监听器随容器一起消亡(404 是预期收场),等它下
- * 次因真实使用而醒来再重新武装;绝不为"接着看"或"收拾干净"把沙箱吵醒。
- * active 走 ref:降温/回暖不重跑 effect,轮询循环自己看当下的状态。
+ * 内存,冻结沙箱的盘也不会变),可以放心轮询;Create 只在 active 时发。
+ * Remove 交给服务端按物理状态裁决,清理本身绝不唤醒。active 走 ref:
+ * 降温/回暖不重跑 effect,单一所有者循环自己看当下状态;冻结保留既有
+ * watcher,只有 not_found 才放下旧 ID 并在真实回暖后重建。
  */
 export function useDirectoryWatch(
   auth: EnvdAuth | undefined,
@@ -123,64 +124,31 @@ export function useDirectoryWatch(
 
   useEffect(() => {
     if (!opts.enabled || !auth) return;
-    let watcherId: string | null = null;
-    let disposed = false;
-    let busy = false;
-
-    const arm = async () => {
-      if (!activeRef.current) return; // 冻结/停止:武装会唤醒,等真实使用
-      try {
-        const id = await createWatcher(auth, path);
-        if (disposed) {
-          // effect 已在建监听的往返途中被拆(切目录或卸载);这个 id 归
-          // 属已死的闭包,同步 cleanup 那时读到的还是 null,拆不掉它 ——
-          // 在此补拆,别把 inotifywait 漏在容器里。active 闸同 cleanup:
-          // 沙箱睡了就留给容器随手回收。
-          if (activeRef.current) {
-            void removeWatcher(auth, id).catch(() => undefined);
-          }
-          return;
+    const watcher = new DirectoryWatcherController({
+      create: () => createWatcher(auth, path),
+      poll: (watcherId) => getWatcherEvents(auth, watcherId),
+      remove: async (watcherId) => {
+        await removeWatcher(auth, watcherId);
+      },
+      isActive: () => activeRef.current,
+      isNotFound: (error) =>
+        error instanceof EnvdError && error.code === 'not_found',
+      onDirty: () => {
+        const queryKey = ['envdDir', auth.sandboxId, path];
+        if (activeRef.current) {
+          void queryClient.invalidateQueries({ queryKey });
+        } else {
+          // Mark stale without refetching: ListDir would wake a frozen sandbox.
+          void queryClient.invalidateQueries({ queryKey, refetchType: 'none' });
         }
-        watcherId = id;
-      } catch {
-        watcherId = null; // 冷启动窗口或目录暂不可达;下一拍再试
-      }
-    };
+      },
+    });
 
-    void arm();
-    const timer = setInterval(() => {
-      if (busy) return;
-      busy = true;
-      void (async () => {
-        if (watcherId === null) {
-          await arm();
-          return;
-        }
-        try {
-          const events = await getWatcherEvents(auth, watcherId);
-          if (events.length > 0) {
-            void queryClient.invalidateQueries({
-              queryKey: ['envdDir', auth.sandboxId, path],
-            });
-          }
-        } catch {
-          // 404:监听器随容器没了(停止/重建)。回到未武装态,由 arm
-          // 的 active 闸决定何时重来 — 绝不在这里直接重建。
-          watcherId = null;
-        }
-      })().finally(() => {
-        busy = false;
-      });
-    }, 2000);
-
+    void watcher.tick();
+    const timer = setInterval(() => void watcher.tick(), 2000);
     return () => {
-      disposed = true;
       clearInterval(timer);
-      // 只有沙箱还醒着才顺手拆(RemoveWatcher 要容器活着);睡了就留给
-      // 容器回收 — 一个 inotifywait 活不过下一次停止。
-      if (watcherId !== null && activeRef.current) {
-        void removeWatcher(auth, watcherId).catch(() => undefined);
-      }
+      watcher.dispose();
     };
   }, [auth, path, opts.enabled, queryClient]);
 }

--- a/packages/console/src/features/sandboxes/hooks/useEnvd.ts
+++ b/packages/console/src/features/sandboxes/hooks/useEnvd.ts
@@ -120,19 +120,7 @@ export function useDirectoryWatch(
 ) {
   const queryClient = useQueryClient();
   const activeRef = useRef(opts.active);
-  const previousActiveRef = useRef(opts.active);
   activeRef.current = opts.active;
-
-  useEffect(() => {
-    const wasActive = previousActiveRef.current;
-    previousActiveRef.current = opts.active;
-    if (!opts.enabled) return;
-    if (!wasActive && opts.active && auth) {
-      void queryClient.invalidateQueries({
-        queryKey: ['envdDir', auth.sandboxId, path],
-      });
-    }
-  }, [auth, opts.active, opts.enabled, path, queryClient]);
 
   useEffect(() => {
     if (!opts.enabled || !auth) return;
@@ -145,9 +133,9 @@ export function useDirectoryWatch(
       isActive: () => activeRef.current,
       isNotFound: (error) =>
         error instanceof EnvdError && error.code === 'not_found',
-      onDirty: () => {
+      onDirty: (active) => {
         const queryKey = ['envdDir', auth.sandboxId, path];
-        if (activeRef.current) {
+        if (active) {
           void queryClient.invalidateQueries({ queryKey });
         } else {
           // Mark stale without refetching: ListDir would wake a frozen sandbox.

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -56,6 +56,8 @@ export interface AppDeps {
    * before anything that needs it.
    */
   logger?: boolean | Logger;
+  /** Tests may inspect the one daemon-wide watcher registry. */
+  watchers?: WatcherTable;
   /**
    * Where the built web console lives; main.ts resolves the monorepo
    * layout, tests inject a fixture. Absent means /console answers an
@@ -113,6 +115,7 @@ export function buildApp({
   executor,
   locks,
   logger = true,
+  watchers = new WatcherTable(),
   consoleDistDir,
   archiver,
   ingress,
@@ -139,7 +142,6 @@ export function buildApp({
   // Process and watcher tables are per-daemon state. The watcher table is
   // also the single deferred-cleanup registry every wake path consults.
   const processes = new ProcessTable();
-  const watchers = new WatcherTable();
 
   // The sandbox port proxy sits in front of routing — it triages by Host
   // header, so it must see the request before Fastify's router 404s a

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -136,6 +136,11 @@ export function buildApp({
   // call shapes would give the instance two different types.
   const loggerInstance =
     typeof logger === 'boolean' ? pino({ enabled: logger }) : logger;
+  // Process and watcher tables are per-daemon state. The watcher table is
+  // also the single deferred-cleanup registry every wake path consults.
+  const processes = new ProcessTable();
+  const watchers = new WatcherTable();
+
   // The sandbox port proxy sits in front of routing — it triages by Host
   // header, so it must see the request before Fastify's router 404s a
   // wildcard host's arbitrary path. Only with the domain knob set; without
@@ -143,7 +148,7 @@ export function buildApp({
   // the factory, so the proxy is exercised over real sockets only.
   let serverFactory: FastifyServerFactory | undefined;
   if (config.DORMICE_SANDBOX_DOMAIN) {
-    const proxy = createSandboxProxy({ config, db, executor, locks });
+    const proxy = createSandboxProxy({ config, db, executor, locks, watchers });
     serverFactory = (handler) => {
       const server = http.createServer((req, res) => {
         if (proxy.matches(req)) proxy.handleRequest(req, res);
@@ -253,6 +258,7 @@ export function buildApp({
       db,
       executor,
       locks,
+      watchers,
       archiver,
       archiveDefaultSeconds,
     });
@@ -299,11 +305,7 @@ export function buildApp({
   });
 
   // The E2B compatibility surface lives beside the native API with its own
-  // auth (X-API-KEY / X-Access-Token) and its own error dialect. The process
-  // and watcher tables are per-daemon state, born with the app and gone
-  // with it — a restart honestly empties them.
-  const processes = new ProcessTable();
-  const watchers = new WatcherTable();
+  // auth (X-API-KEY / X-Access-Token) and its own error dialect.
   app.register(async (compat) => {
     await registerE2bCompat(compat, {
       config,

--- a/packages/server/src/e2b/compat.test.ts
+++ b/packages/server/src/e2b/compat.test.ts
@@ -1813,7 +1813,10 @@ describe('E2B envd surface', () => {
       '/filesystem.Filesystem/RemoveWatcher',
       { watcherId },
     );
-    expect(removed.statusCode).toBe(404);
+    // Container death owns finalization. The fake conducts it synchronously and
+    // answers not_found; Docker may accept the goal-state remove while its exec
+    // exit is still arriving. Neither path may restart the stopped container.
+    expect([200, 404]).toContain(removed.statusCode);
     expect(t.executor.stateOf(sandboxID)).toBe('stopped');
   });
 

--- a/packages/server/src/e2b/compat.test.ts
+++ b/packages/server/src/e2b/compat.test.ts
@@ -20,6 +20,7 @@ import { freezeSandbox, stopSandbox } from '../lifecycle';
 import { sampleOnce } from '../metrics-sampler';
 import { scanOnce } from '../scanner';
 import { mintEnvdToken } from './protocol';
+import { WatcherTable } from './watcher-table';
 
 const MIGRATIONS = fileURLToPath(new URL('../../drizzle', import.meta.url));
 const TOKEN = 'test-token-test-token-test-token';
@@ -46,8 +47,16 @@ function testApp(
     ...env,
   });
   const locks = new KeyedQueue();
-  const app = buildApp({ config, db, executor, locks, logger: false });
-  return { app, db, executor, locks };
+  const watchers = new WatcherTable();
+  const app = buildApp({
+    config,
+    db,
+    executor,
+    locks,
+    watchers,
+    logger: false,
+  });
+  return { app, db, executor, locks, watchers };
 }
 
 type TestApp = ReturnType<typeof testApp>;
@@ -75,6 +84,16 @@ async function createSandbox(
   const res = await control(t, 'POST', '/sandboxes', payload);
   expect(res.statusCode).toBe(201);
   return res.json();
+}
+
+async function registerTemplate(t: TestApp, name: string, image: string) {
+  const res = await t.app.inject({
+    method: 'POST',
+    url: '/registerTemplate',
+    headers: { authorization: `Bearer ${TOKEN}` },
+    payload: { name, image },
+  });
+  expect(res.statusCode).toBe(200);
 }
 
 // The envd token derives from the app's ledger-stored signing secret, not
@@ -1593,9 +1612,14 @@ describe('E2B envd surface', () => {
     });
   });
 
-  it('removing a frozen watcher stays cold and the next real use reaps it', async () => {
+  it('stale frozen wake swaps the shell and reaps its retired watcher', async () => {
     const t = testApp();
-    const { sandboxID } = await createSandbox(t);
+    await registerTemplate(t, 'watch-tpl', 'img-v1');
+    const name = 'watch-reap';
+    const { sandboxID } = await createSandbox(t, {
+      templateID: 'watch-tpl',
+      metadata: { name },
+    });
     const created = await envdRpc(
       t,
       sandboxID,
@@ -1603,7 +1627,10 @@ describe('E2B envd surface', () => {
       { path: '/home/user' },
     );
     const { watcherId } = created.json() as { watcherId: string };
-    await t.locks.run('e2b-test', async () => {
+    await t.executor.writeFiles(sandboxID, [
+      { path: 'keep.txt', content: Buffer.from('survives') },
+    ]);
+    await t.locks.run(name, async () => {
       await freezeSandbox(t.db, t.executor, sandboxID);
     });
 
@@ -1615,12 +1642,19 @@ describe('E2B envd surface', () => {
     );
     expect(removed.statusCode).toBe(200);
     expect(t.executor.stateOf(sandboxID)).toBe('paused');
+    expect(t.watchers.count(sandboxID)).toBe(1);
 
+    await registerTemplate(t, 'watch-tpl', 'img-v2');
     const used = await envdRpc(t, sandboxID, '/filesystem.Filesystem/MakeDir', {
       path: '/home/user/awake',
     });
     expect(used.statusCode).toBe(200);
     expect(t.executor.stateOf(sandboxID)).toBe('running');
+    expect(await t.executor.imageOf(sandboxID)).toBe('img-v2');
+    expect((await t.executor.readFile(sandboxID, 'keep.txt')).toString()).toBe(
+      'survives',
+    );
+    expect(t.watchers.count(sandboxID)).toBe(0);
     const gone = await envdRpc(
       t,
       sandboxID,
@@ -1630,9 +1664,14 @@ describe('E2B envd surface', () => {
     expect(gone.statusCode).toBe(404);
   });
 
-  it('control-plane connect also reaps a frozen retired watcher', async () => {
+  it('control connect swaps a stale frozen shell and reaps its watcher', async () => {
     const t = testApp();
-    const { sandboxID } = await createSandbox(t);
+    await registerTemplate(t, 'connect-tpl', 'img-v1');
+    const name = 'connect-reap';
+    const { sandboxID } = await createSandbox(t, {
+      templateID: 'connect-tpl',
+      metadata: { name },
+    });
     const created = await envdRpc(
       t,
       sandboxID,
@@ -1640,7 +1679,7 @@ describe('E2B envd surface', () => {
       { path: '/home/user' },
     );
     const { watcherId } = created.json() as { watcherId: string };
-    await t.locks.run('e2b-test', async () => {
+    await t.locks.run(name, async () => {
       await freezeSandbox(t.db, t.executor, sandboxID);
     });
     expect(
@@ -1650,16 +1689,17 @@ describe('E2B envd surface', () => {
         })
       ).statusCode,
     ).toBe(200);
+    await registerTemplate(t, 'connect-tpl', 'img-v2');
 
     const connected = await control(
       t,
       'POST',
       `/sandboxes/${sandboxID}/connect`,
-      {
-        timeout: 60,
-      },
+      { timeout: 60 },
     );
     expect(connected.statusCode).toBe(200);
+    expect(await t.executor.imageOf(sandboxID)).toBe('img-v2');
+    expect(t.watchers.count(sandboxID)).toBe(0);
     const gone = await envdRpc(
       t,
       sandboxID,
@@ -1667,6 +1707,61 @@ describe('E2B envd surface', () => {
       { watcherId },
     );
     expect(gone.statusCode).toBe(404);
+  });
+
+  it('stale shell replacement finalizes a live watcher through natural end', async () => {
+    const t = testApp();
+    await registerTemplate(t, 'natural-tpl', 'img-v1');
+    const name = 'natural-end';
+    const { sandboxID } = await createSandbox(t, {
+      templateID: 'natural-tpl',
+      metadata: { name },
+    });
+    const created = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/CreateWatcher',
+      { path: '/home/user' },
+    );
+    const { watcherId } = created.json() as { watcherId: string };
+    await t.locks.run(name, async () => {
+      await freezeSandbox(t.db, t.executor, sandboxID);
+    });
+    await registerTemplate(t, 'natural-tpl', 'img-v2');
+
+    const connected = await control(
+      t,
+      'POST',
+      `/sandboxes/${sandboxID}/connect`,
+      { timeout: 60 },
+    );
+    expect(connected.statusCode).toBe(200);
+    expect(await t.executor.imageOf(sandboxID)).toBe('img-v2');
+    expect(t.watchers.count(sandboxID)).toBe(0);
+    expect(
+      (
+        await envdRpc(t, sandboxID, '/filesystem.Filesystem/GetWatcherEvents', {
+          watcherId,
+        })
+      ).statusCode,
+    ).toBe(404);
+
+    const replacement = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/CreateWatcher',
+      { path: '/home/user' },
+    );
+    expect(replacement.statusCode).toBe(200);
+    expect(t.watchers.count(sandboxID)).toBe(1);
+    expect(
+      (
+        await envdRpc(t, sandboxID, '/filesystem.Filesystem/RemoveWatcher', {
+          watcherId: replacement.json().watcherId,
+        })
+      ).statusCode,
+    ).toBe(200);
+    expect(t.watchers.count(sandboxID)).toBe(0);
   });
 
   it('removing while logically paused still retires without waking', async () => {
@@ -2303,17 +2398,6 @@ describe('browser-direct signed files: the 49983 subdomain form and CORS', () =>
 });
 
 describe('E2B templates', () => {
-  // Registration is a native verb; the compat surface only consumes it.
-  async function registerTemplate(t: TestApp, name: string, image: string) {
-    const res = await t.app.inject({
-      method: 'POST',
-      url: '/registerTemplate',
-      headers: { authorization: `Bearer ${TOKEN}` },
-      payload: { name, image },
-    });
-    expect(res.statusCode).toBe(200);
-  }
-
   it('creates from a registered templateID: its image boots, name echoes as templateID and alias', async () => {
     const t = testApp();
     await registerTemplate(t, 'py311', 'img-py');
@@ -2414,6 +2498,7 @@ describe('E2B surface vs the archiver', () => {
       DORMICE_API_TOKEN: TOKEN,
     });
     const locks = new KeyedQueue();
+    const watchers = new WatcherTable();
     const store = new MemStore();
     const archiver = new Archiver({
       db,
@@ -2427,10 +2512,11 @@ describe('E2B surface vs the archiver', () => {
       db,
       executor,
       locks,
+      watchers,
       logger: false,
       archiver,
     });
-    return { app, db, executor, locks, store, archiver };
+    return { app, db, executor, locks, watchers, store, archiver };
   }
 
   /**

--- a/packages/server/src/e2b/compat.test.ts
+++ b/packages/server/src/e2b/compat.test.ts
@@ -16,6 +16,7 @@ import { getOrCreateSigningSecret } from '../db/secrets';
 import { FAKE_BASE_IMAGE, FakeExecutor } from '../executor/fake';
 import { CpuSampler } from '../host-metrics';
 import { KeyedQueue } from '../keyed-queue';
+import { freezeSandbox, stopSandbox } from '../lifecycle';
 import { sampleOnce } from '../metrics-sampler';
 import { scanOnce } from '../scanner';
 import { mintEnvdToken } from './protocol';
@@ -1590,6 +1591,135 @@ describe('E2B envd surface', () => {
       code: 'not_found',
       message: `watcher with id ${watcherId} not found`,
     });
+  });
+
+  it('removing a frozen watcher stays cold and the next real use reaps it', async () => {
+    const t = testApp();
+    const { sandboxID } = await createSandbox(t);
+    const created = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/CreateWatcher',
+      { path: '/home/user' },
+    );
+    const { watcherId } = created.json() as { watcherId: string };
+    await t.locks.run('e2b-test', async () => {
+      await freezeSandbox(t.db, t.executor, sandboxID);
+    });
+
+    const removed = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/RemoveWatcher',
+      { watcherId },
+    );
+    expect(removed.statusCode).toBe(200);
+    expect(t.executor.stateOf(sandboxID)).toBe('paused');
+
+    const used = await envdRpc(t, sandboxID, '/filesystem.Filesystem/MakeDir', {
+      path: '/home/user/awake',
+    });
+    expect(used.statusCode).toBe(200);
+    expect(t.executor.stateOf(sandboxID)).toBe('running');
+    const gone = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/GetWatcherEvents',
+      { watcherId },
+    );
+    expect(gone.statusCode).toBe(404);
+  });
+
+  it('control-plane connect also reaps a frozen retired watcher', async () => {
+    const t = testApp();
+    const { sandboxID } = await createSandbox(t);
+    const created = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/CreateWatcher',
+      { path: '/home/user' },
+    );
+    const { watcherId } = created.json() as { watcherId: string };
+    await t.locks.run('e2b-test', async () => {
+      await freezeSandbox(t.db, t.executor, sandboxID);
+    });
+    expect(
+      (
+        await envdRpc(t, sandboxID, '/filesystem.Filesystem/RemoveWatcher', {
+          watcherId,
+        })
+      ).statusCode,
+    ).toBe(200);
+
+    const connected = await control(
+      t,
+      'POST',
+      `/sandboxes/${sandboxID}/connect`,
+      {
+        timeout: 60,
+      },
+    );
+    expect(connected.statusCode).toBe(200);
+    const gone = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/GetWatcherEvents',
+      { watcherId },
+    );
+    expect(gone.statusCode).toBe(404);
+  });
+
+  it('removing while logically paused still retires without waking', async () => {
+    const t = testApp();
+    const { sandboxID } = await createSandbox(t);
+    const created = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/CreateWatcher',
+      { path: '/home/user' },
+    );
+    const { watcherId } = created.json() as { watcherId: string };
+    const paused = await control(
+      t,
+      'POST',
+      `/sandboxes/${sandboxID}/pause`,
+      {},
+    );
+    expect(paused.statusCode).toBe(204);
+
+    const removed = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/RemoveWatcher',
+      { watcherId },
+    );
+    expect(removed.statusCode).toBe(200);
+    expect(t.executor.stateOf(sandboxID)).toBe('paused');
+  });
+
+  it('removing after stop does not restart the container', async () => {
+    const t = testApp();
+    const { sandboxID } = await createSandbox(t);
+    const created = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/CreateWatcher',
+      { path: '/home/user' },
+    );
+    const { watcherId } = created.json() as { watcherId: string };
+    await t.locks.run('e2b-test', async () => {
+      await freezeSandbox(t.db, t.executor, sandboxID);
+      await stopSandbox(t.db, t.executor, sandboxID);
+    });
+
+    const removed = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/RemoveWatcher',
+      { watcherId },
+    );
+    expect(removed.statusCode).toBe(404);
+    expect(t.executor.stateOf(sandboxID)).toBe('stopped');
   });
 
   it('a polled watcher dies with its container: the next poll answers not_found', async () => {

--- a/packages/server/src/e2b/control.ts
+++ b/packages/server/src/e2b/control.ts
@@ -98,6 +98,7 @@ export const e2bControlRoutes: FastifyPluginAsyncZod<E2bDeps> = async (
     db,
     executor,
     locks,
+    watchers,
     archiver,
     archiveDefaultSeconds,
     envdSigningSecret,
@@ -313,6 +314,7 @@ export const e2bControlRoutes: FastifyPluginAsyncZod<E2bDeps> = async (
             executor,
             existing,
             request.actor,
+            watchers,
           );
           extendDeadline(awake, timeoutSeconds);
           return touch(db, awake.id);
@@ -392,7 +394,13 @@ export const e2bControlRoutes: FastifyPluginAsyncZod<E2bDeps> = async (
         if (!fresh || e2bView(fresh, new Date()) === 'dead') {
           throw notFound(id);
         }
-        const awake = await wakeSandbox(db, executor, fresh, request.actor);
+        const awake = await wakeSandbox(
+          db,
+          executor,
+          fresh,
+          request.actor,
+          watchers,
+        );
         extendDeadline(awake, request.body.timeout ?? DEFAULT_TIMEOUT_SECONDS);
         return touch(db, awake.id);
       });

--- a/packages/server/src/e2b/envd/shared.ts
+++ b/packages/server/src/e2b/envd/shared.ts
@@ -122,6 +122,11 @@ export interface EnvdContext extends E2bDeps {
     sandboxId: string,
     work: (row: SandboxRow) => Promise<T>,
   ): Promise<T>;
+  /** Serializes daemon-memory work without waking or touching the sandbox. */
+  withoutWake<T>(
+    sandboxId: string,
+    work: (row: SandboxRow) => Promise<T>,
+  ): Promise<T>;
   /** Wake-for-use with streaming-dialect errors: streamError, not thrown JSON. */
   wakeForStream(
     request: FastifyRequest,
@@ -196,7 +201,13 @@ export function createEnvdContext(deps: E2bDeps): EnvdContext {
     await joinRestore(sandboxId);
     return locks.run(before.name, async () => {
       const fresh = requireRunningRow(sandboxId);
-      const awake = await wakeSandbox(db, executor, fresh);
+      const awake = await wakeSandbox(
+        db,
+        executor,
+        fresh,
+        undefined,
+        deps.watchers,
+      );
       return touch(db, awake.id);
     });
   }
@@ -209,10 +220,37 @@ export function createEnvdContext(deps: E2bDeps): EnvdContext {
     await joinRestore(sandboxId);
     return locks.run(before.name, async () => {
       const fresh = requireRunningRow(sandboxId);
-      const awake = await wakeSandbox(db, executor, fresh);
+      const awake = await wakeSandbox(
+        db,
+        executor,
+        fresh,
+        undefined,
+        deps.watchers,
+      );
       const row = touch(db, awake.id);
       try {
         return await work(row);
+      } catch (error) {
+        throw toConnectError(error);
+      }
+    });
+  }
+
+  async function withoutWake<T>(
+    sandboxId: string,
+    work: (row: SandboxRow) => Promise<T>,
+  ): Promise<T> {
+    const before = findById(db, sandboxId);
+    if (!before) {
+      throw new E2bError(502, 'unavailable', 'sandbox not found');
+    }
+    return locks.run(before.name, async () => {
+      const fresh = findById(db, sandboxId);
+      if (!fresh) {
+        throw new E2bError(502, 'unavailable', 'sandbox not found');
+      }
+      try {
+        return await work(fresh);
       } catch (error) {
         throw toConnectError(error);
       }
@@ -241,5 +279,12 @@ export function createEnvdContext(deps: E2bDeps): EnvdContext {
     }
   }
 
-  return { ...deps, requireRunningRow, wakeForUse, inSlot, wakeForStream };
+  return {
+    ...deps,
+    requireRunningRow,
+    wakeForUse,
+    inSlot,
+    withoutWake,
+    wakeForStream,
+  };
 }

--- a/packages/server/src/e2b/envd/watch.ts
+++ b/packages/server/src/e2b/envd/watch.ts
@@ -176,22 +176,24 @@ export function registerWatchRoutes(
   app.post('/filesystem.Filesystem/CreateWatcher', async (request) => {
     const body = request.body as { path?: string; recursive?: boolean };
     if (!body.path) throw connectError('invalid_argument', 'missing path');
-    const row = await ctx.wakeForUse(sandboxIdOf(request));
-    try {
-      const watcherId = await watchers.create({
-        executor,
-        sandboxId: row.id,
-        path: body.path,
-        recursive: body.recursive === true,
-      });
-      return { watcherId };
-    } catch (error) {
-      if (error instanceof WatcherLimitError) {
-        throw connectError('resource_exhausted', error.message);
+    const path = body.path;
+    return ctx.inSlot(sandboxIdOf(request), async (row) => {
+      try {
+        const watcherId = await watchers.create({
+          executor,
+          sandboxId: row.id,
+          path,
+          recursive: body.recursive === true,
+        });
+        return { watcherId };
+      } catch (error) {
+        if (error instanceof WatcherLimitError) {
+          throw connectError('resource_exhausted', error.message);
+        }
+        const { code, message } = watchStartError(error);
+        throw connectError(code, message);
       }
-      const { code, message } = watchStartError(error);
-      throw connectError(code, message);
-    }
+    });
   });
 
   app.post('/filesystem.Filesystem/GetWatcherEvents', async (request) => {
@@ -222,15 +224,20 @@ export function registerWatchRoutes(
     if (!body.watcherId) {
       throw connectError('invalid_argument', 'missing watcher id');
     }
-    // Wakes: stopping the in-container inotifywait needs the container up.
-    const row = await ctx.wakeForUse(sandboxIdOf(request));
-    const removed = await watchers.remove(row.id, body.watcherId);
-    if (!removed) {
-      throw connectError(
-        'not_found',
-        `watcher with id ${body.watcherId} not found`,
-      );
-    }
-    return {};
+    return ctx.withoutWake(sandboxIdOf(request), async (row) => {
+      // A frozen watcher survives physically. Retire it in daemon memory now
+      // and let the next real wake reap it; cleanup must not wake by itself.
+      const removed =
+        row.state === 'active'
+          ? await watchers.remove(row.id, body.watcherId as string)
+          : watchers.retire(row.id, body.watcherId as string);
+      if (!removed) {
+        throw connectError(
+          'not_found',
+          `watcher with id ${body.watcherId} not found`,
+        );
+      }
+      return {};
+    });
   });
 }

--- a/packages/server/src/e2b/watcher-table.test.ts
+++ b/packages/server/src/e2b/watcher-table.test.ts
@@ -4,6 +4,7 @@ import type {
   WatchDirHandle,
   WatchDirOptions,
 } from '../executor/executor';
+import { WatchProcessLifecycle } from '../executor/watch-lifecycle';
 import {
   MAX_WATCHERS_PER_SANDBOX,
   WatcherLimitError,
@@ -131,6 +132,39 @@ describe('WatcherTable', () => {
     expect(table.drain('sandbox-1', id)).toBeUndefined();
     await expect(table.reapRetired('sandbox-1')).resolves.toBeUndefined();
     expect(stop).toHaveBeenCalledTimes(2);
+    expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('retains the record when signal and inspection fail, then reaps it', async () => {
+    const exited = deferred<{ exitCode: number; error: undefined }>();
+    const stopProcess = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('signal failed'))
+      .mockImplementationOnce(async () =>
+        exited.resolve({ exitCode: 137, error: undefined }),
+      );
+    const lifecycle = new WatchProcessLifecycle({
+      exit: exited.promise,
+      stopProcess,
+      classifyFailedStop: vi
+        .fn()
+        .mockRejectedValue(new Error('inspect failed')),
+      onNaturalEnd: vi.fn(),
+    });
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop: () => lifecycle.stop() }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const id = await table.create(args(executor));
+
+    await expect(table.remove('sandbox-1', id)).rejects.toThrow(
+      'container state is unknown',
+    );
+    expect(table.count('sandbox-1')).toBe(1);
+    expect(table.drain('sandbox-1', id)).toBeUndefined();
+
+    await table.reapRetired('sandbox-1');
+    expect(stopProcess).toHaveBeenCalledTimes(2);
     expect(table.count('sandbox-1')).toBe(0);
   });
 

--- a/packages/server/src/e2b/watcher-table.test.ts
+++ b/packages/server/src/e2b/watcher-table.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  Executor,
+  WatchDirHandle,
+  WatchDirOptions,
+} from '../executor/executor';
+import {
+  MAX_WATCHERS_PER_SANDBOX,
+  WatcherLimitError,
+  WatcherTable,
+} from './watcher-table';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const args = (executor: Executor) => ({
+  executor,
+  sandboxId: 'sandbox-1',
+  path: '/home/user',
+  recursive: false,
+});
+
+describe('WatcherTable', () => {
+  it('reserves capacity before concurrent starts complete', async () => {
+    const pending: Array<ReturnType<typeof deferred<WatchDirHandle>>> = [];
+    const executor = {
+      watchDir: vi.fn((_id: string, _opts: WatchDirOptions) => {
+        const next = deferred<WatchDirHandle>();
+        pending.push(next);
+        return next.promise;
+      }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const starts = Array.from({ length: MAX_WATCHERS_PER_SANDBOX }, () =>
+      table.create(args(executor)),
+    );
+
+    await expect(table.create(args(executor))).rejects.toBeInstanceOf(
+      WatcherLimitError,
+    );
+    expect(executor.watchDir).toHaveBeenCalledTimes(MAX_WATCHERS_PER_SANDBOX);
+    for (const item of pending) item.resolve({ stop: async () => {} });
+    await Promise.all(starts);
+  });
+
+  it('releases a reservation when start fails', async () => {
+    const executor = {
+      watchDir: vi.fn().mockRejectedValueOnce(new Error('start failed')),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+
+    await expect(table.create(args(executor))).rejects.toThrow('start failed');
+    expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('does not publish an ID when onEnd wins during startup', async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const executor = {
+      watchDir: vi.fn(async (_id: string, opts: WatchDirOptions) => {
+        opts.onEnd(new Error('died while starting'));
+        return { stop };
+      }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+
+    await expect(table.create(args(executor))).rejects.toThrow(
+      'died while starting',
+    );
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('finalizes explicit removal exactly once when onEnd races it', async () => {
+    let onEnd!: WatchDirOptions['onEnd'];
+    const stop = vi.fn(async () => onEnd(new Error('ended')));
+    const executor = {
+      watchDir: vi.fn(async (_id: string, opts: WatchDirOptions) => {
+        onEnd = opts.onEnd;
+        return { stop };
+      }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const id = await table.create(args(executor));
+
+    await expect(table.remove('sandbox-1', id)).resolves.toBe(true);
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(table.count('sandbox-1')).toBe(0);
+    await expect(table.remove('sandbox-1', id)).resolves.toBe(false);
+  });
+
+  it('shares one physical stop across concurrent cleanup paths', async () => {
+    const pending = deferred<void>();
+    const stop = vi.fn(() => pending.promise);
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const id = await table.create(args(executor));
+    table.retire('sandbox-1', id);
+
+    const first = table.remove('sandbox-1', id);
+    const second = table.reapRetired('sandbox-1');
+    expect(stop).toHaveBeenCalledTimes(1);
+    pending.resolve();
+    await Promise.all([first, second]);
+    expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('keeps a failed active removal retired and retries on the next use', async () => {
+    const stop = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('signal did not land'))
+      .mockResolvedValueOnce(undefined);
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const id = await table.create(args(executor));
+
+    await expect(table.remove('sandbox-1', id)).rejects.toThrow(
+      'signal did not land',
+    );
+    expect(table.count('sandbox-1')).toBe(1);
+    expect(table.drain('sandbox-1', id)).toBeUndefined();
+    await expect(table.reapRetired('sandbox-1')).resolves.toBeUndefined();
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('retires without stopping, then reaps after a legitimate wake', async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const id = await table.create(args(executor));
+
+    expect(table.retire('sandbox-1', id)).toBe(true);
+    expect(stop).not.toHaveBeenCalled();
+    expect(table.drain('sandbox-1', id)).toBeUndefined();
+    expect(table.count('sandbox-1')).toBe(1);
+
+    await table.reapRetired('sandbox-1');
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('keeps watcher IDs scoped to their sandbox', async () => {
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop: async () => {} }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const id = await table.create(args(executor));
+
+    expect(table.drain('sandbox-2', id)).toBeUndefined();
+    expect(table.retire('sandbox-2', id)).toBe(false);
+    await expect(table.remove('sandbox-2', id)).resolves.toBe(false);
+  });
+});

--- a/packages/server/src/e2b/watcher-table.ts
+++ b/packages/server/src/e2b/watcher-table.ts
@@ -8,7 +8,7 @@ import type {
 /**
  * The polling half of directory watching — what the sync SDKs use instead
  * of the WatchDir stream: CreateWatcher parks a watcher here, GetWatcherEvents
- * drains its buffer, RemoveWatcher stops it. Daemon memory, like the process
+ * drains its buffer, RemoveWatcher retires it. Daemon memory, like the process
  * table: a daemon restart empties it honestly, and a watcher's death (its
  * container stopping) deletes its record through physical conduction — the
  * next poll answers not_found, no lifecycle hooks involved.
@@ -18,7 +18,9 @@ import type {
  * this table lives in the host-side daemon, where unbounded means one
  * sandbox writing files in a loop grows the host's memory. The buffer keeps
  * the newest events (oldest dropped first); the per-sandbox watcher count
- * refuses with resource_exhausted.
+ * refuses with resource_exhausted. Starting and retired records count too:
+ * reservations make the ceiling true under concurrent creates, and retired
+ * handles still own a physical process until the next legitimate wake reaps it.
  */
 export const MAX_EVENTS_PER_WATCHER = 8192;
 export const MAX_WATCHERS_PER_SANDBOX = 128;
@@ -30,16 +32,16 @@ interface WatcherRecord {
   watcherId: string;
   sandboxId: string;
   events: WatchEvent[];
-  handle: WatchDirHandle;
+  state: 'starting' | 'active' | 'retired' | 'ended';
+  handle?: WatchDirHandle;
+  endError?: Error;
+  stopPromise?: Promise<void>;
 }
 
 export class WatcherTable {
   private readonly records = new Map<string, WatcherRecord>();
 
-  /**
-   * Starts a watcher and parks it. Path errors (missing, not a directory)
-   * surface as the executor's typed errors, exactly like the streaming face.
-   */
+  /** Starts a watcher, reserving capacity before the executor can yield. */
   async create(args: {
     executor: Executor;
     sandboxId: string;
@@ -47,52 +49,130 @@ export class WatcherTable {
     recursive: boolean;
   }): Promise<string> {
     const { executor, sandboxId, path, recursive } = args;
-    let count = 0;
-    for (const record of this.records.values()) {
-      if (record.sandboxId === sandboxId) count++;
-    }
-    if (count >= MAX_WATCHERS_PER_SANDBOX) {
+    if (this.count(sandboxId) >= MAX_WATCHERS_PER_SANDBOX) {
       throw new WatcherLimitError(
         `sandbox ${sandboxId} already has ${MAX_WATCHERS_PER_SANDBOX} watchers — remove some before creating more`,
       );
     }
-    const watcherId = randomUUID();
-    const events: WatchEvent[] = [];
-    const handle = await executor.watchDir(sandboxId, {
-      path,
-      recursive,
-      onEvent: (event) => {
-        events.push(event);
-        if (events.length > MAX_EVENTS_PER_WATCHER) events.shift();
-      },
-      // The watcher died with its container: the record goes with it, so
-      // the next poll answers not_found — the closest honest translation
-      // of "the envd you were polling is gone".
-      onEnd: () => {
-        this.records.delete(watcherId);
-      },
-    });
-    this.records.set(watcherId, { watcherId, sandboxId, events, handle });
-    return watcherId;
+
+    const record: WatcherRecord = {
+      watcherId: randomUUID(),
+      sandboxId,
+      events: [],
+      state: 'starting',
+    };
+    this.records.set(record.watcherId, record);
+
+    try {
+      const handle = await executor.watchDir(sandboxId, {
+        path,
+        recursive,
+        onEvent: (event) => {
+          if (record.state !== 'starting' && record.state !== 'active') return;
+          record.events.push(event);
+          if (record.events.length > MAX_EVENTS_PER_WATCHER) {
+            record.events.shift();
+          }
+        },
+        onEnd: (error) => {
+          record.endError = error;
+          this.finalize(record);
+        },
+      });
+      record.handle = handle;
+      if (record.state !== 'starting') {
+        const failure =
+          record.endError ?? new Error('watcher retired while starting');
+        record.state = 'retired';
+        await this.stopRetired(record);
+        throw failure;
+      }
+      record.state = 'active';
+      return record.watcherId;
+    } catch (error) {
+      this.finalize(record);
+      throw error;
+    }
   }
 
-  /**
-   * Drains and returns the buffered events — real envd's read-and-reset.
-   * undefined when the watcher does not exist for this sandbox; ids are
-   * sandbox-scoped like pids, so one sandbox cannot poll another's watcher.
-   */
+  /** Living, published watcher events; retired/starting IDs read as absent. */
   drain(sandboxId: string, watcherId: string): WatchEvent[] | undefined {
     const record = this.records.get(watcherId);
-    if (!record || record.sandboxId !== sandboxId) return undefined;
+    if (
+      !record ||
+      record.sandboxId !== sandboxId ||
+      record.state !== 'active'
+    ) {
+      return undefined;
+    }
     return record.events.splice(0, record.events.length);
   }
 
-  /** Stops and forgets a watcher. False when there is nothing to remove. */
+  /**
+   * Retires without touching the container. Frozen cleanup stays cold; the
+   * next real wake calls reapRetired before serving user work.
+   */
+  retire(sandboxId: string, watcherId: string): boolean {
+    const record = this.records.get(watcherId);
+    if (!record || record.sandboxId !== sandboxId) return false;
+    record.state = 'retired';
+    record.events.length = 0;
+    return true;
+  }
+
+  /** Stops now. A failed stop remains retired so the next wake can retry. */
   async remove(sandboxId: string, watcherId: string): Promise<boolean> {
     const record = this.records.get(watcherId);
     if (!record || record.sandboxId !== sandboxId) return false;
-    this.records.delete(watcherId);
-    await record.handle.stop();
+    record.state = 'retired';
+    record.events.length = 0;
+    await this.stopRetired(record);
     return true;
+  }
+
+  /** Reaps deferred frozen cleanup after a legitimate wake made it runnable. */
+  async reapRetired(sandboxId: string): Promise<void> {
+    const retired = [...this.records.values()].filter(
+      (record) => record.sandboxId === sandboxId && record.state === 'retired',
+    );
+    for (const record of retired) {
+      try {
+        await this.stopRetired(record);
+      } catch {
+        // Cleanup is subordinate to the user work that caused this wake.
+        // The record stays retired and the next legitimate wake retries it.
+      }
+    }
+  }
+
+  count(sandboxId: string): number {
+    let count = 0;
+    for (const record of this.records.values()) {
+      if (record.sandboxId === sandboxId && record.state !== 'ended') count++;
+    }
+    return count;
+  }
+
+  private async stopRetired(record: WatcherRecord): Promise<void> {
+    if (record.state === 'ended') return;
+    const handle = record.handle;
+    if (!handle) return;
+    if (!record.stopPromise) {
+      record.stopPromise = handle.stop().then(
+        () => this.finalize(record),
+        (error) => {
+          record.stopPromise = undefined;
+          throw error;
+        },
+      );
+    }
+    await record.stopPromise;
+  }
+
+  private finalize(record: WatcherRecord): void {
+    if (record.state === 'ended') return;
+    record.state = 'ended';
+    this.records.delete(record.watcherId);
+    record.events.length = 0;
   }
 }

--- a/packages/server/src/executor/docker.ts
+++ b/packages/server/src/executor/docker.ts
@@ -1164,16 +1164,24 @@ export class DockerExecutor implements Executor {
     return {
       stop: async () => {
         if (stopped) return;
-        stopped = true;
         try {
           await this.signalProcess(container, sandboxId, pidfile, 'SIGKILL');
-        } catch {
-          // The container is paused or gone: the signal cannot land, so
-          // waiting for the exit would hang. The stopped flag already
-          // silences the watcher; the process itself is reaped by the
-          // container's own death or the 24h backstop.
-          return;
+        } catch (error) {
+          const state = await container.inspect().then(
+            (info) => info.State,
+            () => undefined,
+          );
+          if (!state?.Running || state.Paused) {
+            // A paused/gone container cannot run the signal exec. Keep the
+            // watcher silent; lifecycle death or the 24h backstop reaps it.
+            stopped = true;
+            return;
+          }
+          // The container is still runnable: preserve ownership so a later
+          // legitimate wake/use can retry instead of orphaning inotifywait.
+          throw error;
         }
+        stopped = true;
         await exitInfo;
       },
     };

--- a/packages/server/src/executor/docker.ts
+++ b/packages/server/src/executor/docker.ts
@@ -69,6 +69,7 @@ import {
   type WatchDirHandle,
   type WatchDirOptions,
 } from './executor';
+import { WatchProcessLifecycle } from './watch-lifecycle';
 
 /**
  * Label that marks a container as ours, holding the sandbox id. Listing by
@@ -1086,9 +1087,7 @@ export class DockerExecutor implements Executor {
     const container = this.docker.getContainer(containerId);
     const pidfile = `/tmp/.dormice-exec-${randomUUID()}.pid`;
 
-    // Once true, arriving lines drain and drop — after stop() nothing is
-    // delivered, even the pipe's stragglers.
-    let stopped = false;
+    let lifecycle: WatchProcessLifecycle | undefined;
     let pending = '';
     const onStdout = async (chunk: Buffer) => {
       pending += chunk.toString('utf8');
@@ -1099,7 +1098,7 @@ export class DockerExecutor implements Executor {
         pending = pending.slice(eol + 1);
         for (const event of parseInotifyLine(line, resolved)) {
           // Awaited: backpressure travels through to inotifywait's pipe.
-          if (!stopped) await opts.onEvent(event);
+          if (lifecycle?.delivering !== false) await opts.onEvent(event);
         }
       }
     };
@@ -1153,38 +1152,28 @@ export class DockerExecutor implements Executor {
       );
     }
 
-    void exitInfo.then(({ exitCode, error }) => {
-      if (stopped) return;
-      stopped = true;
-      opts.onEnd(
-        error ?? new Error(`watcher on ${resolved} exited with ${exitCode}`),
-      );
+    lifecycle = new WatchProcessLifecycle({
+      exit: exitInfo,
+      stopProcess: () =>
+        this.signalProcess(container, sandboxId, pidfile, 'SIGKILL'),
+      canRetryStop: async () => {
+        const state = await container.inspect().then(
+          (info) => info.State,
+          () => undefined,
+        );
+        // A paused/gone container cannot run the signal exec. Keep the watcher
+        // silent; lifecycle death or the 24h backstop reaps it. A runnable
+        // container keeps ownership so a later legitimate use can retry.
+        return state?.Running === true && !state.Paused;
+      },
+      onNaturalEnd: ({ exitCode, error }) => {
+        opts.onEnd(
+          error ?? new Error(`watcher on ${resolved} exited with ${exitCode}`),
+        );
+      },
     });
 
-    return {
-      stop: async () => {
-        if (stopped) return;
-        try {
-          await this.signalProcess(container, sandboxId, pidfile, 'SIGKILL');
-        } catch (error) {
-          const state = await container.inspect().then(
-            (info) => info.State,
-            () => undefined,
-          );
-          if (!state?.Running || state.Paused) {
-            // A paused/gone container cannot run the signal exec. Keep the
-            // watcher silent; lifecycle death or the 24h backstop reaps it.
-            stopped = true;
-            return;
-          }
-          // The container is still runnable: preserve ownership so a later
-          // legitimate wake/use can retry instead of orphaning inotifywait.
-          throw error;
-        }
-        stopped = true;
-        await exitInfo;
-      },
-    };
+    return { stop: () => lifecycle?.stop() ?? Promise.resolve() };
   }
 
   /** The buffered face of the exec pipeline: capped sinks, awaited to the end. */

--- a/packages/server/src/executor/docker.ts
+++ b/packages/server/src/executor/docker.ts
@@ -1156,15 +1156,19 @@ export class DockerExecutor implements Executor {
       exit: exitInfo,
       stopProcess: () =>
         this.signalProcess(container, sandboxId, pidfile, 'SIGKILL'),
-      canRetryStop: async () => {
-        const state = await container.inspect().then(
-          (info) => info.State,
-          () => undefined,
-        );
-        // A paused/gone container cannot run the signal exec. Keep the watcher
-        // silent; lifecycle death or the 24h backstop reaps it. A runnable
-        // container keeps ownership so a later legitimate use can retry.
-        return state?.Running === true && !state.Paused;
+      classifyFailedStop: async () => {
+        try {
+          const { State: state } = await container.inspect();
+          // A paused watcher still exists and becomes signalable after the
+          // next legitimate unfreeze. Only proved death releases ownership.
+          return state.Running ? 'retry' : 'terminal';
+        } catch (error) {
+          if (isDockerApiError(error) && error.statusCode === 404) {
+            return 'terminal';
+          }
+          // Unknown is not gone: retain ownership so a later reap can retry.
+          throw error;
+        }
       },
       onNaturalEnd: ({ exitCode, error }) => {
         opts.onEnd(

--- a/packages/server/src/executor/watch-lifecycle.test.ts
+++ b/packages/server/src/executor/watch-lifecycle.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WatchProcessLifecycle } from './watch-lifecycle';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const cleanExit = { exitCode: 137, error: undefined };
+
+describe('WatchProcessLifecycle', () => {
+  it('suppresses onEnd when the process exits during explicit stop', async () => {
+    const exited = deferred<typeof cleanExit>();
+    const onNaturalEnd = vi.fn();
+    const lifecycle = new WatchProcessLifecycle({
+      exit: exited.promise,
+      stopProcess: async () => exited.resolve(cleanExit),
+      canRetryStop: async () => true,
+      onNaturalEnd,
+    });
+
+    await lifecycle.stop();
+
+    expect(onNaturalEnd).not.toHaveBeenCalled();
+    expect(lifecycle.delivering).toBe(false);
+  });
+
+  it('shares one physical stop attempt across concurrent callers', async () => {
+    const exited = deferred<typeof cleanExit>();
+    const signaled = deferred<void>();
+    const stopProcess = vi.fn(() => signaled.promise);
+    const lifecycle = new WatchProcessLifecycle({
+      exit: exited.promise,
+      stopProcess,
+      canRetryStop: async () => true,
+      onNaturalEnd: vi.fn(),
+    });
+
+    const first = lifecycle.stop();
+    const second = lifecycle.stop();
+    await vi.waitFor(() => expect(stopProcess).toHaveBeenCalledTimes(1));
+    expect(second).toBe(first);
+    signaled.resolve();
+    exited.resolve(cleanExit);
+    await first;
+  });
+
+  it('hands ownership back after a runnable transient signal failure', async () => {
+    const exited = deferred<typeof cleanExit>();
+    const onNaturalEnd = vi.fn();
+    const stopProcess = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('docker exec unavailable'))
+      .mockImplementationOnce(async () => exited.resolve(cleanExit));
+    const lifecycle = new WatchProcessLifecycle({
+      exit: exited.promise,
+      stopProcess,
+      canRetryStop: async () => true,
+      onNaturalEnd,
+    });
+
+    await expect(lifecycle.stop()).rejects.toThrow('docker exec unavailable');
+    expect(lifecycle.delivering).toBe(true);
+    await lifecycle.stop();
+
+    expect(stopProcess).toHaveBeenCalledTimes(2);
+    expect(onNaturalEnd).not.toHaveBeenCalled();
+  });
+
+  it('settles cleanup when a failed signal finds the container unavailable', async () => {
+    const exited = deferred<typeof cleanExit>();
+    const onNaturalEnd = vi.fn();
+    const lifecycle = new WatchProcessLifecycle({
+      exit: exited.promise,
+      stopProcess: async () => {
+        throw new Error('container paused');
+      },
+      canRetryStop: async () => false,
+      onNaturalEnd,
+    });
+
+    await lifecycle.stop();
+    exited.resolve(cleanExit);
+    await Promise.resolve();
+
+    expect(lifecycle.delivering).toBe(false);
+    expect(onNaturalEnd).not.toHaveBeenCalled();
+  });
+
+  it('makes a later stop observe an in-progress non-retryable cleanup', async () => {
+    const exited = deferred<typeof cleanExit>();
+    const inspected = deferred<boolean>();
+    const stopProcess = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(new Error('container paused'));
+    const lifecycle = new WatchProcessLifecycle({
+      exit: exited.promise,
+      stopProcess,
+      canRetryStop: () => inspected.promise,
+      onNaturalEnd: vi.fn(),
+    });
+
+    const first = lifecycle.stop();
+    const second = lifecycle.stop();
+    expect(second).toBe(first);
+    inspected.resolve(false);
+    await Promise.all([first, second]);
+
+    expect(stopProcess).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a natural exit exactly once', async () => {
+    const exited = deferred<typeof cleanExit>();
+    const onNaturalEnd = vi.fn();
+    const lifecycle = new WatchProcessLifecycle({
+      exit: exited.promise,
+      stopProcess: vi.fn(),
+      canRetryStop: async () => true,
+      onNaturalEnd,
+    });
+
+    exited.resolve(cleanExit);
+    await vi.waitFor(() =>
+      expect(onNaturalEnd).toHaveBeenCalledWith(cleanExit),
+    );
+    await lifecycle.stop();
+
+    expect(onNaturalEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/server/src/executor/watch-lifecycle.test.ts
+++ b/packages/server/src/executor/watch-lifecycle.test.ts
@@ -3,10 +3,12 @@ import { WatchProcessLifecycle } from './watch-lifecycle';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 const cleanExit = { exitCode: 137, error: undefined };
@@ -18,7 +20,7 @@ describe('WatchProcessLifecycle', () => {
     const lifecycle = new WatchProcessLifecycle({
       exit: exited.promise,
       stopProcess: async () => exited.resolve(cleanExit),
-      canRetryStop: async () => true,
+      classifyFailedStop: async () => 'retry',
       onNaturalEnd,
     });
 
@@ -35,7 +37,7 @@ describe('WatchProcessLifecycle', () => {
     const lifecycle = new WatchProcessLifecycle({
       exit: exited.promise,
       stopProcess,
-      canRetryStop: async () => true,
+      classifyFailedStop: async () => 'retry',
       onNaturalEnd: vi.fn(),
     });
 
@@ -58,7 +60,7 @@ describe('WatchProcessLifecycle', () => {
     const lifecycle = new WatchProcessLifecycle({
       exit: exited.promise,
       stopProcess,
-      canRetryStop: async () => true,
+      classifyFailedStop: async () => 'retry',
       onNaturalEnd,
     });
 
@@ -70,6 +72,55 @@ describe('WatchProcessLifecycle', () => {
     expect(onNaturalEnd).not.toHaveBeenCalled();
   });
 
+  it('keeps cleanup retryable when signal and container inspection both fail', async () => {
+    const exited = deferred<typeof cleanExit>();
+    const signalError = new Error('docker exec unavailable');
+    const inspectError = new Error('docker socket unavailable');
+    const stopProcess = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(signalError)
+      .mockImplementationOnce(async () => exited.resolve(cleanExit));
+    const onNaturalEnd = vi.fn();
+    const lifecycle = new WatchProcessLifecycle({
+      exit: exited.promise,
+      stopProcess,
+      classifyFailedStop: vi.fn().mockRejectedValue(inspectError),
+      onNaturalEnd,
+    });
+
+    const failed = lifecycle.stop().catch((error) => error);
+    await expect(failed).resolves.toMatchObject({
+      message: 'watcher stop failed and container state is unknown',
+      errors: [signalError, inspectError],
+    });
+    expect(lifecycle.delivering).toBe(true);
+    await lifecycle.stop();
+
+    expect(stopProcess).toHaveBeenCalledTimes(2);
+    expect(onNaturalEnd).not.toHaveBeenCalled();
+  });
+
+  it('settles when process exit wins while failed-stop inspection is pending', async () => {
+    const exited = deferred<typeof cleanExit>();
+    const inspected = deferred<'retry'>();
+    const onNaturalEnd = vi.fn();
+    const lifecycle = new WatchProcessLifecycle({
+      exit: exited.promise,
+      stopProcess: vi.fn().mockRejectedValue(new Error('signal failed')),
+      classifyFailedStop: () => inspected.promise,
+      onNaturalEnd,
+    });
+
+    const stopping = lifecycle.stop();
+    exited.resolve(cleanExit);
+    await Promise.resolve();
+    inspected.reject(new Error('inspect failed'));
+    await stopping;
+
+    expect(lifecycle.delivering).toBe(false);
+    expect(onNaturalEnd).not.toHaveBeenCalled();
+  });
+
   it('settles cleanup when a failed signal finds the container unavailable', async () => {
     const exited = deferred<typeof cleanExit>();
     const onNaturalEnd = vi.fn();
@@ -78,7 +129,7 @@ describe('WatchProcessLifecycle', () => {
       stopProcess: async () => {
         throw new Error('container paused');
       },
-      canRetryStop: async () => false,
+      classifyFailedStop: async () => 'terminal',
       onNaturalEnd,
     });
 
@@ -92,21 +143,21 @@ describe('WatchProcessLifecycle', () => {
 
   it('makes a later stop observe an in-progress non-retryable cleanup', async () => {
     const exited = deferred<typeof cleanExit>();
-    const inspected = deferred<boolean>();
+    const inspected = deferred<'terminal'>();
     const stopProcess = vi
       .fn<() => Promise<void>>()
       .mockRejectedValue(new Error('container paused'));
     const lifecycle = new WatchProcessLifecycle({
       exit: exited.promise,
       stopProcess,
-      canRetryStop: () => inspected.promise,
+      classifyFailedStop: () => inspected.promise,
       onNaturalEnd: vi.fn(),
     });
 
     const first = lifecycle.stop();
     const second = lifecycle.stop();
     expect(second).toBe(first);
-    inspected.resolve(false);
+    inspected.resolve('terminal');
     await Promise.all([first, second]);
 
     expect(stopProcess).toHaveBeenCalledTimes(1);
@@ -118,7 +169,7 @@ describe('WatchProcessLifecycle', () => {
     const lifecycle = new WatchProcessLifecycle({
       exit: exited.promise,
       stopProcess: vi.fn(),
-      canRetryStop: async () => true,
+      classifyFailedStop: async () => 'retry',
       onNaturalEnd,
     });
 

--- a/packages/server/src/executor/watch-lifecycle.ts
+++ b/packages/server/src/executor/watch-lifecycle.ts
@@ -3,11 +3,12 @@ interface WatchExit {
   error: Error | undefined;
 }
 
+export type FailedStopDisposition = 'retry' | 'terminal';
+
 interface WatchProcessLifecycleOptions {
   exit: Promise<WatchExit>;
   stopProcess(): Promise<void>;
-  /** True only while another stop attempt can still reach the process. */
-  canRetryStop(): Promise<boolean>;
+  classifyFailedStop(): Promise<FailedStopDisposition>;
   onNaturalEnd(outcome: WatchExit): void;
 }
 
@@ -60,14 +61,29 @@ export class WatchProcessLifecycle {
     if (this.exited) return;
     try {
       await this.opts.stopProcess();
-    } catch (error) {
-      const canRetry = this.exited ? false : await this.opts.canRetryStop();
-      if (this.exited || !canRetry) {
+    } catch (signalError) {
+      let disposition: FailedStopDisposition;
+      try {
+        disposition = this.exited
+          ? 'terminal'
+          : await this.opts.classifyFailedStop();
+      } catch (inspectError) {
+        if (this.exited) {
+          this.state = 'stopped';
+          return;
+        }
+        this.state = 'running';
+        throw new AggregateError(
+          [signalError, inspectError],
+          'watcher stop failed and container state is unknown',
+        );
+      }
+      if (this.exited || disposition === 'terminal') {
         this.state = 'stopped';
         return;
       }
       this.state = 'running';
-      throw error;
+      throw signalError;
     }
     await this.opts.exit;
     this.state = 'stopped';

--- a/packages/server/src/executor/watch-lifecycle.ts
+++ b/packages/server/src/executor/watch-lifecycle.ts
@@ -1,0 +1,75 @@
+interface WatchExit {
+  exitCode: number;
+  error: Error | undefined;
+}
+
+interface WatchProcessLifecycleOptions {
+  exit: Promise<WatchExit>;
+  stopProcess(): Promise<void>;
+  /** True only while another stop attempt can still reach the process. */
+  canRetryStop(): Promise<boolean>;
+  onNaturalEnd(outcome: WatchExit): void;
+}
+
+/**
+ * Arbitrates one physical watcher process between natural exit and explicit
+ * stop. Marking `stopping` before signaling is the identity point: an exit in
+ * that window belongs to stop(), not onNaturalEnd. A failed signal hands that
+ * identity back only while the process is still reachable for a later retry.
+ */
+export class WatchProcessLifecycle {
+  private state: 'running' | 'stopping' | 'stopped' = 'running';
+  private exited = false;
+  private stopPromise: Promise<void> | undefined;
+
+  constructor(private readonly opts: WatchProcessLifecycleOptions) {
+    void opts.exit.then((outcome) => {
+      this.exited = true;
+      if (this.state !== 'running') {
+        this.state = 'stopped';
+        return;
+      }
+      this.state = 'stopped';
+      opts.onNaturalEnd(outcome);
+    });
+  }
+
+  get delivering(): boolean {
+    return this.state === 'running';
+  }
+
+  stop(): Promise<void> {
+    if (this.state === 'stopped') return Promise.resolve();
+    if (this.stopPromise) return this.stopPromise;
+
+    this.state = 'stopping';
+    const attempt = this.stopOnce();
+    this.stopPromise = attempt;
+    void attempt.then(
+      () => {
+        if (this.stopPromise === attempt) this.stopPromise = undefined;
+      },
+      () => {
+        if (this.stopPromise === attempt) this.stopPromise = undefined;
+      },
+    );
+    return attempt;
+  }
+
+  private async stopOnce(): Promise<void> {
+    if (this.exited) return;
+    try {
+      await this.opts.stopProcess();
+    } catch (error) {
+      const canRetry = this.exited ? false : await this.opts.canRetryStop();
+      if (this.exited || !canRetry) {
+        this.state = 'stopped';
+        return;
+      }
+      this.state = 'running';
+      throw error;
+    }
+    await this.opts.exit;
+    this.state = 'stopped';
+  }
+}

--- a/packages/server/src/lifecycle.ts
+++ b/packages/server/src/lifecycle.ts
@@ -10,6 +10,7 @@ import {
 import { deleteSandboxMetricsSamples } from './db/metrics';
 import type { SandboxRow } from './db/schema';
 import { resolveImage } from './db/templates';
+import type { WatcherTable } from './e2b/watcher-table';
 import type { Executor } from './executor/executor';
 
 /**
@@ -191,9 +192,11 @@ export async function wakeSandbox(
   executor: Executor,
   row: SandboxRow,
   actor?: string | null,
+  watchers?: WatcherTable,
 ): Promise<SandboxRow> {
   switch (row.state) {
     case 'active':
+      await watchers?.reapRetired(row.id);
       return row;
     case 'frozen':
     case 'stopped': {
@@ -211,6 +214,7 @@ export async function wakeSandbox(
           : row;
       if (fresh.state === 'frozen') {
         await executor.unfreeze(fresh.id);
+        await watchers?.reapRetired(fresh.id);
         return awaken(
           db,
           fresh,
@@ -223,6 +227,7 @@ export async function wakeSandbox(
       await executor.start(fresh.id, {
         image: resolveImage(db, fresh.template),
       });
+      await watchers?.reapRetired(fresh.id);
       return awaken(db, fresh, 'cold start from the surviving disk', actor);
     }
     case 'archived':

--- a/packages/server/src/routes/sandboxes.ts
+++ b/packages/server/src/routes/sandboxes.ts
@@ -61,6 +61,7 @@ import {
 import type { SandboxRow } from '../db/schema';
 import { readRuntimeSettings } from '../db/settings';
 import { findTemplate, resolveImage } from '../db/templates';
+import type { WatcherTable } from '../e2b/watcher-table';
 import { startExecHeartbeat } from '../exec-heartbeat';
 import {
   type Executor,
@@ -78,6 +79,7 @@ export interface SandboxRoutesOptions {
   db: Db;
   executor: Executor;
   locks: KeyedQueue;
+  watchers: WatcherTable;
   /** Absent = no S3 configured: archiving and restores are honestly off. */
   archiver?: Archiver;
   /** buildApp's one adjudication of the archive policy default (null = off). */
@@ -127,7 +129,7 @@ export const sandboxRoutes: FastifyPluginAsyncZod<
   SandboxRoutesOptions
 > = async (
   app,
-  { config, db, executor, locks, archiver, archiveDefaultSeconds },
+  { config, db, executor, locks, watchers, archiver, archiveDefaultSeconds },
 ) => {
   // Every sandbox lives on this daemon today, so the endpoint is our own
   // address; with sharding it may point at another node.
@@ -183,7 +185,7 @@ export const sandboxRoutes: FastifyPluginAsyncZod<
       // Requested template and metadata are not applied: like policy, they
       // take effect only when this acquire creates the sandbox (metadata
       // has its own update verb, updateMetadata).
-      const awake = await wakeSandbox(db, executor, existing, actor);
+      const awake = await wakeSandbox(db, executor, existing, actor, watchers);
       return { status: 'ready', created: false, row: touch(db, awake.id) };
     }
 
@@ -245,7 +247,7 @@ export const sandboxRoutes: FastifyPluginAsyncZod<
         `sandbox "${name}" is ${existing.state} — call acquireSandbox and poll until it is ready`,
       );
     }
-    const awake = await wakeSandbox(db, executor, existing, actor);
+    const awake = await wakeSandbox(db, executor, existing, actor, watchers);
     return touch(db, awake.id);
   }
 

--- a/packages/server/src/sandbox-proxy.ts
+++ b/packages/server/src/sandbox-proxy.ts
@@ -7,6 +7,7 @@ import type { Db } from './db/db';
 import { findById, touch } from './db/ledger';
 import type { SandboxRow } from './db/schema';
 import { e2bView } from './e2b/view';
+import type { WatcherTable } from './e2b/watcher-table';
 import { startExecHeartbeat } from './exec-heartbeat';
 import type { Executor } from './executor/executor';
 import type { KeyedQueue } from './keyed-queue';
@@ -76,6 +77,7 @@ export interface SandboxProxyDeps {
   db: Db;
   executor: Executor;
   locks: KeyedQueue;
+  watchers: WatcherTable;
 }
 
 export interface SandboxProxy {
@@ -88,7 +90,7 @@ export interface SandboxProxy {
 class ProxyRefusal extends Error {}
 
 export function createSandboxProxy(deps: SandboxProxyDeps): SandboxProxy {
-  const { config, db, executor, locks } = deps;
+  const { config, db, executor, locks, watchers } = deps;
   const domain = config.DORMICE_SANDBOX_DOMAIN ?? '';
 
   function liveRow(sandboxId: string): SandboxRow {
@@ -118,7 +120,7 @@ export function createSandboxProxy(deps: SandboxProxyDeps): SandboxProxy {
     const before = liveRow(parsed.sandboxId);
     const row = await locks.run(before.name, async () => {
       const fresh = liveRow(parsed.sandboxId);
-      const awake = await wakeSandbox(db, executor, fresh);
+      const awake = await wakeSandbox(db, executor, fresh, undefined, watchers);
       return touch(db, awake.id);
     });
     const target = await executor.resolvePortTarget(row.id, parsed.port);


### PR DESCRIPTION
## What changed

- Preserves MoonWindow’s original late-`CreateWatcher` teardown fix and contributor authorship.
- Replaces independent effect flags with a single-owner, single-flight watcher controller.
- Retains a live watcher across freezes and transient poll errors; only confirmed `not_found` re-arms it.
- Marks frozen directory queries stale without refetching, then refreshes exactly once after thaw.
- Serializes watcher creation/removal with sandbox lifecycle operations.
- Makes `RemoveWatcher` no-wake: active watchers stop immediately; cold watchers retire and reap on the next legitimate use.
- Reserves watcher capacity before asynchronous starts and centralizes finalization across startup, natural-end, removal, and retry races.
- Retains cleanup ownership when both signaling and Docker inspection fail; a later legitimate wake retries it.
- Preserves stale-image convergence: replacement makes the new shell runnable before retired watchers are reaped.
- Wires the one daemon-wide watcher table through native RPC, E2B control, envd, and port-proxy wake paths.

## Regression coverage

- Console controller: normal/late teardown, single-flight create, freeze survival and thaw refresh, transient poll convergence, `not_found` re-arm, disposal during poll, rapid effect generations.
- Server table/lifecycle: concurrent capacity, failed start rollback, early `onEnd`, removal races, shared physical stop, signal+inspect failure retry, process-exit race, deferred reap, sandbox scoping.
- E2B compatibility: polling trio, frozen no-wake removal, envd/control wake reaping, logical pause, stopped cleanup, stale frozen image replacement, retained disk data, and natural watcher finalization.
- Counterproof: temporarily restoring the late-create leak makes the focused controller tests fail.

## Verification

Exact final head: `4b6aaeae3e1a7458bb6bf4c518a06b4eb161d371`

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `shellcheck deploy/install.sh`
- `pnpm test`
  - console: 20 passed
  - server: 543 passed
  - SDK: 31 passed
  - CLI: 59 passed
  - e2e: 86 passed / 11 skipped
- Google Linux host, Docker 29.6.2 + gVisor `release-20260622.0`:
  - exact behavior SHA `d7d3c729221593a2f4289be437e09050734b8b1b`: Docker executor contract 93/93 passed;
  - targeted watcher/API/E2B suite 193/193 passed;
  - live create/event/drain and active remove passed;
  - frozen `RemoveWatcher` stayed paused, connect reaped it, old ID returned `not_found`;
  - stale frozen shell swapped `dormice-base:pr15-v1 -> pr15-v2`, retained disk data, reaped a retired watcher, and naturally finalized a live watcher;
  - all test containers, mounts, image aliases, templates, and temporary artifacts were removed; daemon remained healthy.
- Final test-only head `4b6aaea`: deployed and healthy; `compat.test.ts` 78/78 passed on the same host.

## Follow-up protocol work

This PR intentionally does not close:

- #17 — replay-safe `CreateWatcher` after a lost response;
- #18 — goal-state `RemoveWatcher` convergence after a lost response;
- #20 — durable cleanup ownership for streaming `WatchDir`.
