### PR TITLE
Keep expired console sessions on the login path

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "dev": "vite",
     "seed": "node scripts/seed.mjs",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/console/src/lib/api.test.ts
+++ b/packages/console/src/lib/api.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+function stubBrowser(options: { signedIn?: boolean } = {}) {
+  const storage = new Map<string, string>();
+  if (options.signedIn) storage.set('dormice.console.signed-in', '1');
+
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  });
+
+  const redirects: string[] = [];
+  const location = {
+    pathname: '/console/sandboxes/alice',
+    search: '?tab=files',
+    hash: '#preview',
+    replace: (value: string) => redirects.push(value),
+  };
+  vi.stubGlobal('window', { location });
+  return { storage, redirects };
+}
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+async function expectPending(promise: Promise<unknown>) {
+  const fulfilled = vi.fn();
+  const rejected = vi.fn();
+  void promise.then(fulfilled, rejected);
+
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(fulfilled).not.toHaveBeenCalled();
+  expect(rejected).not.toHaveBeenCalled();
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('console RPC transport', () => {
+  it('returns a valid JSON response', async () => {
+    stubBrowser();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ sandboxes: [] })),
+    );
+    const { listSandboxes } = await import('./api');
+
+    await expect(listSandboxes()).resolves.toEqual({ sandboxes: [] });
+  });
+
+  it('throws a named ApiError with the daemon message', async () => {
+    stubBrowser();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ message: 'nope' }, 403)),
+    );
+    const { listSandboxes } = await import('./api');
+
+    await expect(listSandboxes()).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 403,
+      message: 'nope',
+    });
+  });
+
+  it('falls back to route and status for a malformed error body', async () => {
+    stubBrowser();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('not json', { status: 500 })),
+    );
+    const { listSandboxes } = await import('./api');
+
+    await expect(listSandboxes()).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 500,
+      message: '/listSandboxes failed with 500',
+    });
+  });
+
+  it.each([
+    ['empty 200', new Response(null, { status: 200 })],
+    ['malformed 200', new Response('not json', { status: 200 })],
+    ['empty 204', new Response(null, { status: 204 })],
+  ])('rejects %s instead of inventing a typed success', async (_label, res) => {
+    stubBrowser();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(res));
+    const { listSandboxes } = await import('./api');
+
+    await expect(listSandboxes()).rejects.toMatchObject({
+      name: 'ApiError',
+      status: res.status,
+      message: `/listSandboxes returned invalid JSON with ${res.status}`,
+      cause: expect.anything(),
+    });
+  });
+
+  it('redirects an expired session without settling the RPC', async () => {
+    const { storage, redirects } = stubBrowser({ signedIn: true });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse({ message: 'missing or invalid API token' }, 401),
+        ),
+    );
+    const { listSandboxes } = await import('./api');
+
+    const request = listSandboxes();
+    await expectPending(request);
+    expect(storage.has('dormice.console.signed-in')).toBe(false);
+    expect(redirects).toEqual([
+      '/console/login?redirect=%2Fconsole%2Fsandboxes%2Falice%3Ftab%3Dfiles%23preview',
+    ]);
+  });
+
+  it('holds concurrent 401s behind the same single redirect', async () => {
+    const { redirects } = stubBrowser({ signedIn: true });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse({ message: 'missing or invalid API token' }, 401),
+        ),
+    );
+    const { getConfig, listSandboxes } = await import('./api');
+
+    const first = listSandboxes();
+    const second = getConfig();
+    await expectPending(first);
+    await expectPending(second);
+    expect(redirects).toHaveLength(1);
+  });
+
+  it('rejects a protected 401 when no signed-in marker exists', async () => {
+    const { redirects } = stubBrowser();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ message: 'unauthorized' }, 401)),
+    );
+    const { listSandboxes } = await import('./api');
+
+    await expect(listSandboxes()).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 401,
+      message: 'unauthorized',
+    });
+    expect(redirects).toEqual([]);
+  });
+
+  it('keeps login 401s local to the form', async () => {
+    const { storage, redirects } = stubBrowser({ signedIn: true });
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse({ message: 'invalid username or password' }, 401),
+        ),
+    );
+    const { login } = await import('./api');
+
+    await expect(
+      login({ username: 'x', password: 'wrongpass' }),
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 401,
+      message: 'invalid username or password',
+    });
+    expect(storage.has('dormice.console.signed-in')).toBe(true);
+    expect(redirects).toEqual([]);
+  });
+});

--- a/packages/console/src/lib/api.ts
+++ b/packages/console/src/lib/api.ts
@@ -37,10 +37,15 @@ export class ApiError extends Error {
   constructor(
     message: string,
     readonly status: number,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
+    this.name = 'ApiError';
   }
 }
+
+const redirectingUnauthorized = new Promise<never>(() => {});
+let unauthorizedRedirectStarted = false;
 
 /**
  * Session-expiry backstop, in one place instead of per page: any business
@@ -49,12 +54,22 @@ export class ApiError extends Error {
  * do a full-page jump to the login route — a reload guarantees no leftover
  * query cache or component state survives, and the redirect param brings
  * the operator back to where they were.
+ *
+ * The latch covers concurrent calls: the first response clears the marker,
+ * so later 401s cannot use the marker alone to know a redirect is underway.
  */
-function interceptUnauthorized(): void {
-  if (!hasSessionMarker()) return;
+function interceptUnauthorized(): boolean {
+  if (unauthorizedRedirectStarted) return true;
+  if (!hasSessionMarker()) return false;
+
+  unauthorizedRedirectStarted = true;
   clearSessionMarker();
-  const here = window.location.pathname + window.location.search;
-  window.location.href = `/console/login?redirect=${encodeURIComponent(here)}`;
+  const here =
+    window.location.pathname + window.location.search + window.location.hash;
+  window.location.replace(
+    `/console/login?redirect=${encodeURIComponent(here)}`,
+  );
+  return true;
 }
 
 async function rpc<T>(
@@ -70,8 +85,8 @@ async function rpc<T>(
     },
     body: JSON.stringify(body),
   });
-  if (res.status === 401 && intercept401) {
-    interceptUnauthorized();
+  if (res.status === 401 && intercept401 && interceptUnauthorized()) {
+    return redirectingUnauthorized;
   }
   if (!res.ok) {
     const message = await res
@@ -83,7 +98,15 @@ async function rpc<T>(
       res.status,
     );
   }
-  return res.json() as Promise<T>;
+  try {
+    return (await res.json()) as T;
+  } catch (cause) {
+    throw new ApiError(
+      `${path} returned invalid JSON with ${res.status}`,
+      res.status,
+      { cause },
+    );
+  }
 }
 
 // Whether setup has happened — the login page's fork: no account yet means


### PR DESCRIPTION
## What & why

Closes #14.

A protected console RPC that received 401 started a full-page login redirect and then continued into the normal error path. Queries could briefly paint an error and mutations could toast while the document was already leaving. The first response also cleared the session marker, so concurrent 401s could not infer that navigation was underway.

Keep redirected calls behind one document-lifetime pending promise, latch concurrent 401s, replace the stale protected history entry, and preserve pathname, search, and hash for the return trip. Authentication-form calls keep their local 401 behavior. Native RPC successes remain strict JSON; malformed or empty success bodies now fail with route and status context instead of a bare parser error. `ApiError` also reports its own name.

The console now owns focused transport tests for valid and malformed responses, local auth failures, one expired-session redirect, and concurrent 401s.

## Checklist

- [x] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` passes locally (build first — the e2e suite runs the built daemon)
- [x] Behavior changes come with tests that fail without the change
- [x] User-facing changes to `@dormice/shared` / `sdk` / `cli` have a changeset (`pnpm changeset`) — not applicable; console is private
- [x] README updated if this changes documented behavior — not applicable; existing session-expiry contract is unchanged

Additional CI-equivalent check: `shellcheck deploy/install.sh` passes.

## Browser acceptance

- Built the exact PR SHA `5d88ced`.
- Drove the production console bundle with two concurrent protected RPCs returning 401.
- Observed one replacement navigation to `/console/login`, the stale session marker cleared, and the complete return target `/console/sandboxes?view=all#active` preserved.
- No query error or mutation toast rendered before navigation.
