### PR TITLE
Make watcher operations converge after lost responses

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: verify
+summary: Drive Dormice's built daemon over its public HTTP and E2B surfaces.
+---
+
+# Verify Dormice runtime behavior
+
+1. Run `pnpm build` before verification; the black-box surface is `packages/server/dist/main.js`.
+2. Launch an isolated fake daemon with an unused port, a temporary absolute `DORMICE_DB_PATH`/`DORMICE_DATA_DIR`, a 64-hex `DORMICE_API_TOKEN`, and `DORMICE_EXECUTOR=fake`.
+3. Wait for `GET /healthz`, then drive native or E2B routes only over HTTP. E2B control auth is `X-API-KEY: e2b_<token>`; envd requests use the returned `sandboxID`/`envdAccessToken` as `E2b-Sandbox-Id` and `X-Access-Token`.
+4. Connect streaming requests use one envelope: flag byte `0`, four-byte big-endian JSON length, then JSON bytes. Parse responses as repeated envelopes.
+5. Capture response status/body inline. Probe malformed input, replay/concurrency, and resource cleanup around the claimed flow.
+6. Stop the daemon and remove its temporary directory. Docker/gVisor process facts require the Linux test host and cannot be established with the fake executor.

--- a/e2e/src/e2b.test.ts
+++ b/e2e/src/e2b.test.ts
@@ -624,7 +624,11 @@ describe('official e2b SDK against the daemon', () => {
       const { envdAccessToken } = (await connectRes.json()) as {
         envdAccessToken: string;
       };
-      const rpc = async (method: string, body: Record<string, unknown>) => {
+      const rpc = async (
+        method: string,
+        body: Record<string, unknown>,
+        headers: Record<string, string> = {},
+      ) => {
         const res = await fetch(
           `${inject('dormiceEndpoint')}/e2b/envd/filesystem.Filesystem/${method}`,
           {
@@ -633,6 +637,7 @@ describe('official e2b SDK against the daemon', () => {
               'content-type': 'application/json',
               'e2b-sandbox-id': sbx.sandboxId,
               'x-access-token': envdAccessToken,
+              ...headers,
             },
             body: JSON.stringify(body),
           },
@@ -642,9 +647,21 @@ describe('official e2b SDK against the daemon', () => {
           json: (await res.json()) as Record<string, unknown>,
         };
       };
-      const created = await rpc('CreateWatcher', { path: '/home/user' });
+      const operationId = crypto.randomUUID();
+      const created = await rpc(
+        'CreateWatcher',
+        { path: '/home/user' },
+        { 'x-dormice-watcher-operation-id': operationId },
+      );
       expect(created.status).toBe(200);
       const watcherId = created.json.watcherId as string;
+      // Model a lost first response by issuing the same operation again.
+      const replayed = await rpc(
+        'CreateWatcher',
+        { path: '/home/user/./' },
+        { 'x-dormice-watcher-operation-id': operationId },
+      );
+      expect(replayed).toEqual({ status: 200, json: { watcherId } });
 
       await sbx.files.write('polled.txt', 'x');
       // Poll like a sync SDK: drain until the event shows up.
@@ -665,6 +682,9 @@ describe('official e2b SDK against the daemon', () => {
 
       const removed = await rpc('RemoveWatcher', { watcherId });
       expect(removed.status).toBe(200);
+      // A retry after the successful response was lost is still success.
+      const removedAgain = await rpc('RemoveWatcher', { watcherId });
+      expect(removedAgain.status).toBe(200);
       const gone = await rpc('GetWatcherEvents', { watcherId });
       expect(gone.status).toBe(404);
       expect(gone.json.code).toBe('not_found');

--- a/packages/console/src/features/sandboxes/envd-client.ts
+++ b/packages/console/src/features/sandboxes/envd-client.ts
@@ -29,8 +29,9 @@ export class EnvdError extends Error {
     message: string,
     readonly code: string | undefined,
     readonly status: number,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
   }
 }
 
@@ -38,10 +39,15 @@ async function unary<T>(
   auth: EnvdAuth,
   rpc: string,
   body: unknown,
+  extraHeaders: Record<string, string> = {},
 ): Promise<T> {
   const res = await fetch(`${ENVD}/${rpc}`, {
     method: 'POST',
-    headers: { ...headersOf(auth), 'content-type': 'application/json' },
+    headers: {
+      ...headersOf(auth),
+      ...extraHeaders,
+      'content-type': 'application/json',
+    },
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -54,7 +60,16 @@ async function unary<T>(
       res.status,
     );
   }
-  return res.json() as Promise<T>;
+  try {
+    return (await res.json()) as T;
+  } catch (error) {
+    throw new EnvdError(
+      `${rpc} 响应无效`,
+      undefined,
+      0,
+      error instanceof Error ? { cause: error } : undefined,
+    );
+  }
 }
 
 // ---- Filesystem(unary Connect RPC,JSON 编码)---------------------------
@@ -104,10 +119,17 @@ export interface EnvdWatchEvent {
   type: string;
 }
 
-export const createWatcher = (auth: EnvdAuth, path: string) =>
-  unary<{ watcherId: string }>(auth, 'filesystem.Filesystem/CreateWatcher', {
-    path,
-  }).then((r) => r.watcherId);
+export const createWatcher = (
+  auth: EnvdAuth,
+  path: string,
+  operationId: string,
+) =>
+  unary<{ watcherId: string }>(
+    auth,
+    'filesystem.Filesystem/CreateWatcher',
+    { path },
+    { 'x-dormice-watcher-operation-id': operationId },
+  ).then((r) => r.watcherId);
 
 /** 只读不唤醒(与 Process/List 同一原则):挂着监听不养沙箱的体温。 */
 export const getWatcherEvents = (auth: EnvdAuth, watcherId: string) =>

--- a/packages/console/src/features/sandboxes/hooks/directory-watcher.test.ts
+++ b/packages/console/src/features/sandboxes/hooks/directory-watcher.test.ts
@@ -16,7 +16,9 @@ function deferred<T>() {
 }
 
 function harness(overrides: Partial<DirectoryWatcherDeps> = {}) {
-  const create = vi.fn<() => Promise<string>>().mockResolvedValue('watch-1');
+  const create = vi
+    .fn<(operationId: string) => Promise<string>>()
+    .mockResolvedValue('watch-1');
   const poll = vi
     .fn<(id: string) => Promise<EnvdWatchEvent[]>>()
     .mockResolvedValue([]);
@@ -30,6 +32,9 @@ function harness(overrides: Partial<DirectoryWatcherDeps> = {}) {
     isActive: () => active,
     isNotFound: (error) =>
       error instanceof EnvdError && error.code === 'not_found',
+    isRetryable: (error) => !(error instanceof EnvdError),
+    operationId: () => 'operation-1',
+    delay: async () => {},
     onDirty,
     ...overrides,
   });
@@ -89,6 +94,81 @@ describe('DirectoryWatcherController', () => {
     await t.controller.tick();
     expect(t.poll).toHaveBeenCalledWith('watch-1');
     expect(t.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses one operation ID while retrying an ambiguous create outcome', async () => {
+    const create = vi
+      .fn<(operationId: string) => Promise<string>>()
+      .mockRejectedValueOnce(new Error('response lost'))
+      .mockResolvedValueOnce('watch-1');
+    const t = harness({ create });
+
+    await t.controller.tick();
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls).toEqual([['operation-1'], ['operation-1']]);
+  });
+
+  it('recovers and removes an ambiguous create after disposal', async () => {
+    const create = vi
+      .fn<(operationId: string) => Promise<string>>()
+      .mockRejectedValueOnce(new Error('response lost 1'))
+      .mockRejectedValueOnce(new Error('response lost 2'))
+      .mockRejectedValueOnce(new Error('response lost 3'))
+      .mockResolvedValueOnce('watch-1');
+    const t = harness({ create });
+    await t.controller.tick();
+    expect(create).toHaveBeenCalledTimes(3);
+
+    t.controller.dispose();
+
+    await vi.waitFor(() => expect(t.remove).toHaveBeenCalledWith('watch-1'));
+    expect(create.mock.calls).toEqual([
+      ['operation-1'],
+      ['operation-1'],
+      ['operation-1'],
+      ['operation-1'],
+    ]);
+  });
+
+  it('does not retry a deterministic create error', async () => {
+    const create = vi
+      .fn<(operationId: string) => Promise<string>>()
+      .mockRejectedValue(new EnvdError('bad path', 'invalid_argument', 400));
+    const t = harness({ create });
+
+    await t.controller.tick();
+
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries ambiguous remove outcomes with bounded backoff', async () => {
+    const remove = vi
+      .fn<(id: string) => Promise<void>>()
+      .mockRejectedValueOnce(new Error('response lost'))
+      .mockResolvedValueOnce(undefined);
+    const delay = vi.fn().mockResolvedValue(undefined);
+    const t = harness({ remove, delay });
+    await t.controller.tick();
+
+    t.controller.dispose();
+
+    await vi.waitFor(() => expect(remove).toHaveBeenCalledTimes(2));
+    expect(remove).toHaveBeenNthCalledWith(1, 'watch-1');
+    expect(remove).toHaveBeenNthCalledWith(2, 'watch-1');
+    expect(delay).toHaveBeenCalledWith(100);
+  });
+
+  it('does not retry deterministic remove errors', async () => {
+    const remove = vi
+      .fn<(id: string) => Promise<void>>()
+      .mockRejectedValue(new EnvdError('unauthorized', 'unauthenticated', 401));
+    const t = harness({ remove });
+    await t.controller.tick();
+
+    t.controller.dispose();
+
+    await vi.waitFor(() => expect(remove).toHaveBeenCalledTimes(1));
   });
 
   it('retains the watcher after a transient poll error', async () => {

--- a/packages/console/src/features/sandboxes/hooks/directory-watcher.ts
+++ b/packages/console/src/features/sandboxes/hooks/directory-watcher.ts
@@ -1,24 +1,38 @@
 import type { EnvdWatchEvent } from '../envd-client';
 
 export interface DirectoryWatcherDeps {
-  create(): Promise<string>;
+  create(operationId: string): Promise<string>;
   poll(watcherId: string): Promise<EnvdWatchEvent[]>;
   remove(watcherId: string): Promise<void>;
   isActive(): boolean;
   isNotFound(error: unknown): boolean;
+  isRetryable(error: unknown): boolean;
+  operationId(): string;
+  delay(milliseconds: number): Promise<void>;
   onDirty(active: boolean): void;
 }
+
+const MAX_CREATE_ATTEMPTS = 3;
+const MAX_REMOVE_ATTEMPTS = 3;
+const retryDelayMs = (attempt: number) => Math.min(100 * 2 ** attempt, 400);
 
 /**
  * One effect generation's ownership of one polling watcher. Every arm/poll
  * goes through the same single-flight tick; dispose takes the published ID,
  * while an ID still in flight is retired by the create continuation itself.
+ *
+ * A create generation also owns one operation UUID: ambiguous HTTP outcomes
+ * replay with that UUID, so a response lost after server success recovers the
+ * same watcher instead of allocating another. Cleanup retries only ambiguous
+ * transport/server outcomes and remains private fire-and-forget to React.
  */
 export class DirectoryWatcherController {
   private watcherId: string | null = null;
+  private operationId: string | null = null;
   private disposed = false;
   private inactiveDirty = false;
   private inFlight: Promise<void> | null = null;
+  private releasePromise: Promise<void> | null = null;
 
   constructor(private readonly deps: DirectoryWatcherDeps) {}
 
@@ -42,19 +56,42 @@ export class DirectoryWatcherController {
     if (this.disposed) return;
     this.disposed = true;
     const id = this.takeWatcher();
-    if (id) void this.release(id);
+    if (id) {
+      void this.release(id);
+      return;
+    }
+    const operationId = this.operationId;
+    this.operationId = null;
+    if (operationId && !this.inFlight) {
+      void this.recoverAndRelease(operationId);
+    }
   }
 
   private async runTick(): Promise<void> {
     const current = this.watcherId;
     if (current === null) {
       if (!this.deps.isActive()) return;
-      let created: string;
-      try {
-        created = await this.deps.create();
-      } catch {
-        return;
+      const operationId = this.operationId ?? this.deps.operationId();
+      this.operationId = operationId;
+      let created: string | undefined;
+      for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {
+        try {
+          created = await this.deps.create(operationId);
+          break;
+        } catch (error) {
+          if (!this.deps.isRetryable(error)) return;
+          if (attempt === MAX_CREATE_ATTEMPTS - 1) {
+            if (this.disposed) {
+              this.operationId = null;
+              void this.recoverAndRelease(operationId);
+            }
+            return;
+          }
+          await this.deps.delay(retryDelayMs(attempt));
+        }
       }
+      if (!created) return;
+      this.operationId = null;
       if (this.disposed) {
         await this.release(created);
         return;
@@ -71,10 +108,29 @@ export class DirectoryWatcherController {
     } catch (error) {
       if (this.deps.isNotFound(error) && this.watcherId === current) {
         this.watcherId = null;
+        this.operationId = null;
       } else if (!this.disposed && this.watcherId === current) {
         // Drain is destructive at the daemon. A lost response may have eaten
         // events, so the directory must converge even though this ID remains.
         this.reportDirty();
+      }
+    }
+  }
+
+  private async recoverAndRelease(operationId: string): Promise<void> {
+    for (let attempt = 0; attempt < MAX_CREATE_ATTEMPTS; attempt++) {
+      try {
+        const watcherId = await this.deps.create(operationId);
+        await this.release(watcherId);
+        return;
+      } catch (error) {
+        if (
+          !this.deps.isRetryable(error) ||
+          attempt === MAX_CREATE_ATTEMPTS - 1
+        ) {
+          return;
+        }
+        await this.deps.delay(retryDelayMs(attempt));
       }
     }
   }
@@ -91,11 +147,29 @@ export class DirectoryWatcherController {
     return id;
   }
 
-  private async release(watcherId: string): Promise<void> {
-    try {
-      await this.deps.remove(watcherId);
-    } catch {
-      // Gone already is the cleanup goal; lifecycle races are expected here.
+  private release(watcherId: string): Promise<void> {
+    if (this.releasePromise) return this.releasePromise;
+    const release = this.releaseWithRetry(watcherId).finally(() => {
+      if (this.releasePromise === release) this.releasePromise = null;
+    });
+    this.releasePromise = release;
+    return release;
+  }
+
+  private async releaseWithRetry(watcherId: string): Promise<void> {
+    for (let attempt = 0; attempt < MAX_REMOVE_ATTEMPTS; attempt++) {
+      try {
+        await this.deps.remove(watcherId);
+        return;
+      } catch (error) {
+        if (
+          !this.deps.isRetryable(error) ||
+          attempt === MAX_REMOVE_ATTEMPTS - 1
+        ) {
+          return;
+        }
+        await this.deps.delay(retryDelayMs(attempt));
+      }
     }
   }
 }

--- a/packages/console/src/features/sandboxes/hooks/useEnvd.ts
+++ b/packages/console/src/features/sandboxes/hooks/useEnvd.ts
@@ -18,6 +18,20 @@ import {
 } from '../envd-client';
 import { DirectoryWatcherController } from './directory-watcher';
 
+function operationId(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes.set([((bytes.at(6) ?? 0) & 0x0f) | 0x40], 6);
+  bytes.set([((bytes.at(8) ?? 0) & 0x3f) | 0x80], 8);
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0'));
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10).join(''),
+  ].join('-');
+}
+
 /**
  * 一个沙箱的 envd 面数据层:token、文件、进程。token 是无状态 HMAC,
  * 不过期 — 铸一次缓存整个会话(轮换 API token 才作废,那时 401 拦截兜底)。
@@ -125,7 +139,7 @@ export function useDirectoryWatch(
   useEffect(() => {
     if (!opts.enabled || !auth) return;
     const watcher = new DirectoryWatcherController({
-      create: () => createWatcher(auth, path),
+      create: (operationId) => createWatcher(auth, path, operationId),
       poll: (watcherId) => getWatcherEvents(auth, watcherId),
       remove: async (watcherId) => {
         await removeWatcher(auth, watcherId);
@@ -133,6 +147,14 @@ export function useDirectoryWatch(
       isActive: () => activeRef.current,
       isNotFound: (error) =>
         error instanceof EnvdError && error.code === 'not_found',
+      isRetryable: (error) =>
+        !(error instanceof EnvdError) ||
+        error.status === 408 ||
+        error.status === 429 ||
+        error.status >= 500,
+      operationId,
+      delay: (milliseconds) =>
+        new Promise<void>((resolve) => setTimeout(resolve, milliseconds)),
       onDirty: (active) => {
         const queryKey = ['envdDir', auth.sandboxId, path];
         if (active) {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -171,6 +171,12 @@ export function buildApp({
   }).withTypeProvider<ZodTypeProvider>();
   app.setValidatorCompiler(validatorCompiler);
   app.setSerializerCompiler(serializerCompiler);
+  // Streaming WatchDir requests stay open until their watcher is stopped;
+  // preClose must cut those resources before Fastify waits for in-flight
+  // requests to drain. onClose would never be reached while a stream is live.
+  app.addHook('preClose', async () => {
+    await watchers.shutdown();
+  });
 
   // The single arbiter for the wire's error shape: every non-2xx body is
   // { message }, whoever produced the error. Without this, Fastify's own

--- a/packages/server/src/archive/archiver.test.ts
+++ b/packages/server/src/archive/archiver.test.ts
@@ -4,10 +4,12 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_LIFECYCLE_POLICY } from '@dormice/shared';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { type Db, migrateDb, openDb } from '../db/db';
 import { createSandbox, findByName, transition } from '../db/ledger';
 import type { SandboxRow } from '../db/schema';
+import { WatcherTable } from '../e2b/watcher-table';
+import type { Executor } from '../executor/executor';
 import { FakeExecutor } from '../executor/fake';
 import { KeyedQueue } from '../keyed-queue';
 import { Archiver } from './archiver';
@@ -23,8 +25,16 @@ function setup() {
   const locks = new KeyedQueue();
   const store = new MemStore();
   const tmpDir = mkdtempSync(path.join(tmpdir(), 'dormice-archiver-'));
-  const archiver = new Archiver({ db, executor, locks, store, tmpDir });
-  return { db, executor, locks, store, tmpDir, archiver };
+  const watchers = new WatcherTable();
+  const archiver = new Archiver({
+    db,
+    executor,
+    locks,
+    store,
+    tmpDir,
+    watchers,
+  });
+  return { db, executor, locks, store, tmpDir, watchers, archiver };
 }
 
 /** A stopped sandbox with a marker file — the archiver's raw material. */
@@ -169,6 +179,33 @@ describe('Archiver.beginRestore', () => {
     // "the row is archived" — release never chases stale copies.
     expect(store.has(objectKey(row.id))).toBe(false);
     expect(readdirSync(tmpDir)).toEqual([]);
+  });
+
+  it('reaps deferred watcher cleanup before restored user work resumes', async () => {
+    const { db, executor, watchers, archiver } = setup();
+    const row = await seedStopped(db, executor, 'alice');
+    await archiver.archive(row);
+    const stop = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('cleanup deferred'))
+      .mockResolvedValueOnce(undefined);
+    const watcherExecutor = {
+      watchDir: vi.fn().mockResolvedValue({ stop }),
+    } as unknown as Executor;
+    const watcherId = await watchers.create({
+      executor: watcherExecutor,
+      sandboxId: row.id,
+      path: '/home/user',
+      recursive: false,
+    });
+    await expect(
+      watchers.removeGoal(row.id, watcherId, { runnable: true }),
+    ).rejects.toThrow('cleanup deferred');
+
+    await archiver.restoreJoin(row.id);
+
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(watchers.count(row.id)).toBe(0);
   });
 
   it('a missing archive object reverts the row to archived', async () => {

--- a/packages/server/src/archive/archiver.ts
+++ b/packages/server/src/archive/archiver.ts
@@ -5,6 +5,7 @@ import type { Db } from '../db/db';
 import { findById, setPausedByUser, touch, transition } from '../db/ledger';
 import type { SandboxRow } from '../db/schema';
 import { resolveImage } from '../db/templates';
+import type { WatcherTable } from '../e2b/watcher-table';
 import type { Executor } from '../executor/executor';
 import type { KeyedQueue } from '../keyed-queue';
 import { type ArchiveStore, objectKey } from './store';
@@ -36,6 +37,7 @@ export interface ArchiverDeps {
    */
   tmpDir: string;
   log?: (msg: string) => void;
+  watchers?: WatcherTable;
 }
 
 function clampPercent(fraction: number): number {
@@ -56,6 +58,7 @@ export class Archiver {
   private readonly locks: KeyedQueue;
   private readonly tmpDir: string;
   private readonly log: (msg: string) => void;
+  private readonly watchers: WatcherTable | undefined;
   private readonly restores = new Map<string, RestoreEntry>();
 
   constructor(deps: ArchiverDeps) {
@@ -65,6 +68,7 @@ export class Archiver {
     this.store = deps.store;
     this.tmpDir = deps.tmpDir;
     this.log = deps.log ?? (() => {});
+    this.watchers = deps.watchers;
   }
 
   /**
@@ -221,6 +225,7 @@ export class Archiver {
         await this.executor.start(sandboxId, {
           image: resolveImage(this.db, fresh.template),
         });
+        await this.watchers?.reapDeferred(sandboxId);
         // Awaken semantics, like every wake: an awake sandbox is by
         // definition not paused — without this, an autoPause-archived row
         // would restore into a logically-paused sandbox no one can reach.

--- a/packages/server/src/e2b/compat.test.ts
+++ b/packages/server/src/e2b/compat.test.ts
@@ -1612,6 +1612,114 @@ describe('E2B envd surface', () => {
     });
   });
 
+  it('replays CreateWatcher by operation ID and rejects a mismatched payload', async () => {
+    const t = testApp();
+    const { sandboxID } = await createSandbox(t);
+    const operationId = '11111111-1111-4111-8111-111111111111';
+    const create = (path: string, recursive = false) =>
+      t.app.inject({
+        method: 'POST',
+        url: '/e2b/envd/filesystem.Filesystem/CreateWatcher',
+        headers: {
+          ...envdHeaders(t, sandboxID),
+          'x-dormice-watcher-operation-id': operationId,
+        },
+        payload: { path, recursive },
+      });
+
+    // Treat the first response as lost: the replay still recovers its ID.
+    const first = await create('/home/user');
+    const replay = await create('/home/user/./');
+    expect(replay.statusCode).toBe(200);
+    expect(replay.json()).toEqual(first.json());
+    expect(t.watchers.count(sandboxID)).toBe(1);
+
+    const conflict = await create('/home/user/other');
+    expect(conflict.statusCode).toBe(409);
+    expect(conflict.json().code).toBe('already_exists');
+    expect(t.watchers.count(sandboxID)).toBe(1);
+
+    const removed = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/RemoveWatcher',
+      first.json() as { watcherId: string },
+    );
+    expect(removed.statusCode).toBe(200);
+  });
+
+  it('validates operation and watcher IDs at the envd boundary', async () => {
+    const t = testApp();
+    const { sandboxID } = await createSandbox(t);
+    const malformedOperation = await t.app.inject({
+      method: 'POST',
+      url: '/e2b/envd/filesystem.Filesystem/CreateWatcher',
+      headers: {
+        ...envdHeaders(t, sandboxID),
+        'x-dormice-watcher-operation-id': 'not-a-uuid',
+      },
+      payload: { path: '/home/user' },
+    });
+    expect(malformedOperation.statusCode).toBe(400);
+    expect(malformedOperation.json().code).toBe('invalid_argument');
+
+    const malformedWatcher = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/RemoveWatcher',
+      { watcherId: 'not-a-uuid' },
+    );
+    expect(malformedWatcher.statusCode).toBe(400);
+    expect(malformedWatcher.json().code).toBe('invalid_argument');
+  });
+
+  it('RemoveWatcher is a goal-state operation after lost responses and across sandboxes', async () => {
+    const t = testApp();
+    const { sandboxID } = await createSandbox(t);
+    const { sandboxID: otherSandbox } = await createSandbox(t);
+    const created = await envdRpc(
+      t,
+      sandboxID,
+      '/filesystem.Filesystem/CreateWatcher',
+      { path: '/home/user' },
+    );
+    const { watcherId } = created.json() as { watcherId: string };
+
+    // The other sandbox must not learn that this ID exists or affect it.
+    const crossSandbox = await envdRpc(
+      t,
+      otherSandbox,
+      '/filesystem.Filesystem/RemoveWatcher',
+      { watcherId },
+    );
+    expect(crossSandbox.statusCode).toBe(200);
+    expect(t.watchers.count(sandboxID)).toBe(1);
+
+    // Discard the first successful response, then replay after finalization.
+    expect(
+      (
+        await envdRpc(t, sandboxID, '/filesystem.Filesystem/RemoveWatcher', {
+          watcherId,
+        })
+      ).statusCode,
+    ).toBe(200);
+    expect(
+      (
+        await envdRpc(t, sandboxID, '/filesystem.Filesystem/RemoveWatcher', {
+          watcherId,
+        })
+      ).statusCode,
+    ).toBe(200);
+    expect(
+      (
+        await envdRpc(t, sandboxID, '/filesystem.Filesystem/RemoveWatcher', {
+          watcherId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        })
+      ).statusCode,
+    ).toBe(200);
+    expect(t.watchers.count(sandboxID)).toBe(0);
+  });
+
   it('stale frozen wake swaps the shell and reaps its retired watcher', async () => {
     const t = testApp();
     await registerTemplate(t, 'watch-tpl', 'img-v1');
@@ -1813,10 +1921,9 @@ describe('E2B envd surface', () => {
       '/filesystem.Filesystem/RemoveWatcher',
       { watcherId },
     );
-    // Container death owns finalization. The fake conducts it synchronously and
-    // answers not_found; Docker may accept the goal-state remove while its exec
-    // exit is still arriving. Neither path may restart the stopped container.
-    expect([200, 404]).toContain(removed.statusCode);
+    // Container death owns physical finalization; goal-state remove is stable
+    // whether its exit conduction already arrived or is still in flight.
+    expect(removed.statusCode).toBe(200);
     expect(t.executor.stateOf(sandboxID)).toBe('stopped');
   });
 
@@ -2509,6 +2616,7 @@ describe('E2B surface vs the archiver', () => {
       locks,
       store,
       tmpDir: mkdtempSync(path.join(tmpdir(), 'dormice-compat-')),
+      watchers,
     });
     const app = buildApp({
       config,

--- a/packages/server/src/e2b/control.ts
+++ b/packages/server/src/e2b/control.ts
@@ -332,6 +332,7 @@ export const e2bControlRoutes: FastifyPluginAsyncZod<E2bDeps> = async (
               cause: 'protocol-dead row reaped by E2B create',
               actor: request.actor,
             },
+            watchers,
           );
         }
 
@@ -535,11 +536,18 @@ export const e2bControlRoutes: FastifyPluginAsyncZod<E2bDeps> = async (
     await locks.run(row.name, async () => {
       const fresh = findById(db, id);
       if (!fresh) throw notFound(id);
-      await destroySandbox(db, executor, fresh.id, archiver?.store ?? null, {
-        kind: 'destroyed',
-        cause: 'via E2B kill',
-        actor: request.actor,
-      });
+      await destroySandbox(
+        db,
+        executor,
+        fresh.id,
+        archiver?.store ?? null,
+        {
+          kind: 'destroyed',
+          cause: 'via E2B kill',
+          actor: request.actor,
+        },
+        watchers,
+      );
     });
     return reply.code(204).send();
   });
@@ -596,6 +604,7 @@ export const e2bControlRoutes: FastifyPluginAsyncZod<E2bDeps> = async (
             current.id,
             'paused via E2B (memory discarded)',
             request.actor,
+            watchers,
           );
         }
         setPausedByUser(db, fresh.id, true);

--- a/packages/server/src/e2b/envd/shared.ts
+++ b/packages/server/src/e2b/envd/shared.ts
@@ -115,6 +115,8 @@ export function streamError(
 export interface EnvdContext extends E2bDeps {
   /** The protocol-liveness gate: only a logically-running sandbox serves envd traffic. */
   requireRunningRow(sandboxId: string): SandboxRow;
+  /** Current ledger state says the container can receive a cleanup signal. */
+  isRunnable(sandboxId: string): boolean;
   /** Wake under the key's slot, like every native verb. */
   wakeForUse(sandboxId: string): Promise<SandboxRow>;
   /** Unary filesystem RPCs run entirely in the key's slot, like native file verbs. */
@@ -193,6 +195,10 @@ export function createEnvdContext(deps: E2bDeps): EnvdContext {
    * Wake under the key's slot, like every native verb: physical wake-ups
    * take seconds and must not race the scanner or a destroy.
    */
+  function isRunnable(sandboxId: string): boolean {
+    return findById(db, sandboxId)?.state === 'active';
+  }
+
   async function wakeForUse(sandboxId: string): Promise<SandboxRow> {
     // The logical gate first: a paused-by-deadline sandbox answers 502
     // whether it is frozen or archived — restoring it for a request that
@@ -282,6 +288,7 @@ export function createEnvdContext(deps: E2bDeps): EnvdContext {
   return {
     ...deps,
     requireRunningRow,
+    isRunnable,
     wakeForUse,
     inSlot,
     withoutWake,

--- a/packages/server/src/e2b/envd/watch.ts
+++ b/packages/server/src/e2b/envd/watch.ts
@@ -1,5 +1,5 @@
 import type { Buffer } from 'node:buffer';
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
 import {
   FileNotFoundError,
   NotADirectoryError,
@@ -12,7 +12,11 @@ import {
   FLAG_MESSAGE,
   readFirstMessage,
 } from '../protocol';
-import { WatcherLimitError } from '../watcher-table';
+import {
+  WatcherLimitError,
+  WatcherOperationConflictError,
+  WatcherOperationLimitError,
+} from '../watcher-table';
 import {
   type EnvdContext,
   MAX_KEEPALIVE_SECONDS,
@@ -30,6 +34,34 @@ const WATCH_EVENT_WIRE: Record<WatchEvent['type'], string> = {
   rename: 'EVENT_TYPE_RENAME',
   chmod: 'EVENT_TYPE_CHMOD',
 };
+
+export const WATCHER_OPERATION_HEADER = 'x-dormice-watcher-operation-id';
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function operationIdOf(request: FastifyRequest): string | undefined {
+  const header = request.headers[WATCHER_OPERATION_HEADER];
+  const value = Array.isArray(header) ? header[0] : header;
+  if (value === undefined) return undefined;
+  const normalized = value.toLowerCase();
+  if (!UUID.test(normalized)) {
+    throw connectError(
+      'invalid_argument',
+      `${WATCHER_OPERATION_HEADER} must be a UUID`,
+    );
+  }
+  return normalized;
+}
+
+function watcherIdOf(body: { watcherId?: string }): string {
+  if (!body.watcherId) {
+    throw connectError('invalid_argument', 'missing watcher id');
+  }
+  if (!UUID.test(body.watcherId)) {
+    throw connectError('invalid_argument', 'watcher id must be a UUID');
+  }
+  return body.watcherId.toLowerCase();
+}
 
 /**
  * Path validation errors travel differently on the two watch surfaces
@@ -78,8 +110,27 @@ export function registerWatchRoutes(
     if (!message.path) {
       return streamError(reply, 'invalid_argument', 'missing path');
     }
-    const row = await ctx.wakeForStream(request, reply);
-    if (!row) return;
+    const sandboxId = sandboxIdOf(request);
+    let reservationId: string;
+    try {
+      reservationId = watchers.reserveStreaming(sandboxId);
+    } catch (error) {
+      if (error instanceof WatcherLimitError) {
+        return streamError(reply, 'resource_exhausted', error.message);
+      }
+      throw error;
+    }
+    let row: Awaited<ReturnType<typeof ctx.wakeForStream>>;
+    try {
+      row = await ctx.wakeForStream(request, reply);
+    } catch (error) {
+      watchers.cancelStreamingReservation(sandboxId, reservationId);
+      throw error;
+    }
+    if (!row) {
+      watchers.cancelStreamingReservation(sandboxId, reservationId);
+      return;
+    }
 
     const write = rawWriter(reply);
     // Events hold at this gate until the start frame is on the wire — the
@@ -93,9 +144,12 @@ export function registerWatchRoutes(
     const ended = new Promise<Error>((resolve) => {
       settleEnd = resolve;
     });
-    let watcher: Awaited<ReturnType<typeof executor.watchDir>>;
+    let watcherId: string;
     try {
-      watcher = await executor.watchDir(row.id, {
+      watcherId = await watchers.createStreaming({
+        executor,
+        sandboxId: row.id,
+        reservationId,
         path: message.path,
         recursive: message.recursive === true,
         onEvent: async (event) => {
@@ -113,6 +167,9 @@ export function registerWatchRoutes(
           settleEnd(error ?? new Error('watcher ended unexpectedly')),
       });
     } catch (error) {
+      if (error instanceof WatcherLimitError) {
+        return streamError(reply, 'resource_exhausted', error.message);
+      }
       const { code, message: text } = watchStartError(error);
       return streamError(reply, code, text);
     }
@@ -162,9 +219,11 @@ export function registerWatchRoutes(
       clearInterval(keepalive);
       clearTimeout(deadlineTimer);
       try {
-        await watcher.stop();
-      } catch {
-        // The sandbox died under the watcher; its ending already spoke.
+        await watchers.closeStreaming(row.id, watcherId, {
+          runnable: ctx.isRunnable(row.id),
+        });
+      } catch (error) {
+        request.log.warn(error, 'streaming watcher cleanup deferred');
       }
       reply.raw.end();
     }
@@ -177,6 +236,7 @@ export function registerWatchRoutes(
     const body = request.body as { path?: string; recursive?: boolean };
     if (!body.path) throw connectError('invalid_argument', 'missing path');
     const path = body.path;
+    const operationId = operationIdOf(request);
     return ctx.inSlot(sandboxIdOf(request), async (row) => {
       try {
         const watcherId = await watchers.create({
@@ -184,11 +244,18 @@ export function registerWatchRoutes(
           sandboxId: row.id,
           path,
           recursive: body.recursive === true,
+          operationId,
         });
         return { watcherId };
       } catch (error) {
-        if (error instanceof WatcherLimitError) {
+        if (
+          error instanceof WatcherLimitError ||
+          error instanceof WatcherOperationLimitError
+        ) {
           throw connectError('resource_exhausted', error.message);
+        }
+        if (error instanceof WatcherOperationConflictError) {
+          throw connectError('already_exists', error.message);
         }
         const { code, message } = watchStartError(error);
         throw connectError(code, message);
@@ -220,23 +287,15 @@ export function registerWatchRoutes(
   });
 
   app.post('/filesystem.Filesystem/RemoveWatcher', async (request) => {
-    const body = request.body as { watcherId?: string };
-    if (!body.watcherId) {
-      throw connectError('invalid_argument', 'missing watcher id');
-    }
+    const watcherId = watcherIdOf(request.body as { watcherId?: string });
     return ctx.withoutWake(sandboxIdOf(request), async (row) => {
-      // A frozen watcher survives physically. Retire it in daemon memory now
-      // and let the next real wake reap it; cleanup must not wake by itself.
-      const removed =
-        row.state === 'active'
-          ? await watchers.remove(row.id, body.watcherId as string)
-          : watchers.retire(row.id, body.watcherId as string);
-      if (!removed) {
-        throw connectError(
-          'not_found',
-          `watcher with id ${body.watcherId} not found`,
-        );
-      }
+      // The verb expresses the goal "this ID is absent from this sandbox".
+      // Unknown and cross-sandbox IDs already satisfy it and deliberately look
+      // alike. Only a physically active sandbox can accept a signal now; every
+      // colder or protocol-dead state retires in memory without waking.
+      await watchers.removeGoal(row.id, watcherId, {
+        runnable: row.state === 'active',
+      });
       return {};
     });
   });

--- a/packages/server/src/e2b/watcher-table.test.ts
+++ b/packages/server/src/e2b/watcher-table.test.ts
@@ -8,6 +8,8 @@ import { WatchProcessLifecycle } from '../executor/watch-lifecycle';
 import {
   MAX_WATCHERS_PER_SANDBOX,
   WatcherLimitError,
+  WatcherOperationConflictError,
+  WatcherOperationLimitError,
   WatcherTable,
 } from './watcher-table';
 
@@ -184,6 +186,248 @@ describe('WatcherTable', () => {
     await table.reapRetired('sandbox-1');
     expect(stop).toHaveBeenCalledTimes(1);
     expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('replays one operation sequentially and concurrently without another watcher', async () => {
+    const pending = deferred<WatchDirHandle>();
+    const executor = {
+      watchDir: vi.fn(() => pending.promise),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const operationId = '11111111-1111-4111-8111-111111111111';
+
+    const first = table.create({ ...args(executor), operationId });
+    const concurrent = table.create({
+      ...args(executor),
+      path: '/home/user/./',
+      operationId,
+    });
+    expect(executor.watchDir).toHaveBeenCalledTimes(1);
+    expect(table.count('sandbox-1')).toBe(1);
+    pending.resolve({ stop: async () => {} });
+
+    const [watcherId, replayed] = await Promise.all([first, concurrent]);
+    expect(replayed).toBe(watcherId);
+    await expect(
+      table.create({ ...args(executor), operationId }),
+    ).resolves.toBe(watcherId);
+    expect(executor.watchDir).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an operation replay with a different canonical request', async () => {
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop: async () => {} }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const operationId = '22222222-2222-4222-8222-222222222222';
+    const watcherId = await table.create({ ...args(executor), operationId });
+
+    await expect(
+      table.create({
+        ...args(executor),
+        path: '/home/user/other',
+        operationId,
+      }),
+    ).rejects.toBeInstanceOf(WatcherOperationConflictError);
+    await expect(
+      table.create({ ...args(executor), recursive: true, operationId }),
+    ).rejects.toBeInstanceOf(WatcherOperationConflictError);
+    expect(table.drain('sandbox-1', watcherId)).toEqual([]);
+    expect(executor.watchDir).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains a live operation across expiry and prunes only its completed tombstone', async () => {
+    let now = 0;
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop }),
+    } as unknown as Executor;
+    const table = new WatcherTable({
+      now: () => now,
+      operationRetentionMs: 10,
+    });
+    const operationId = '33333333-3333-4333-8333-333333333333';
+    const watcherId = await table.create({ ...args(executor), operationId });
+
+    now = 100;
+    await expect(
+      table.create({ ...args(executor), operationId }),
+    ).resolves.toBe(watcherId);
+    expect(executor.watchDir).toHaveBeenCalledTimes(1);
+
+    await table.removeGoal('sandbox-1', watcherId);
+    expect(table.count('sandbox-1')).toBe(0);
+    expect(table.operationCount('sandbox-1')).toBe(1);
+    await expect(
+      table.create({ ...args(executor), operationId }),
+    ).resolves.toBe(watcherId);
+
+    now = 111;
+    expect(table.operationCount('sandbox-1')).toBe(0);
+    const replacement = await table.create({ ...args(executor), operationId });
+    expect(replacement).not.toBe(watcherId);
+    expect(executor.watchDir).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases a failed operation and bounds retained operation state', async () => {
+    const executor = {
+      watchDir: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('start failed'))
+        .mockResolvedValue({ stop: async () => {} }),
+    } as unknown as Executor;
+    const table = new WatcherTable({ maxOperationsPerSandbox: 1 });
+    const firstId = '44444444-4444-4444-8444-444444444444';
+    await expect(
+      table.create({ ...args(executor), operationId: firstId }),
+    ).rejects.toThrow('start failed');
+    expect(table.operationCount('sandbox-1')).toBe(0);
+    await table.create({ ...args(executor), operationId: firstId });
+
+    await expect(
+      table.create({
+        ...args(executor),
+        operationId: '55555555-5555-4555-8555-555555555555',
+      }),
+    ).rejects.toBeInstanceOf(WatcherOperationLimitError);
+  });
+
+  it('makes repeated and cross-sandbox goal removal converge without another stop', async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const id = await table.create(args(executor));
+
+    await table.removeGoal('sandbox-2', id);
+    expect(stop).not.toHaveBeenCalled();
+    await Promise.all([
+      table.removeGoal('sandbox-1', id),
+      table.removeGoal('sandbox-1', id),
+    ]);
+    await table.removeGoal('sandbox-1', id);
+    await table.removeGoal('sandbox-1', 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('reserves streaming capacity before physical start and releases a refused wake', () => {
+    const table = new WatcherTable();
+    for (let index = 0; index < MAX_WATCHERS_PER_SANDBOX; index++) {
+      table.reserveStreaming('sandbox-1');
+    }
+    expect(() => table.reserveStreaming('sandbox-1')).toThrow(
+      WatcherLimitError,
+    );
+
+    table.disposeSandbox('sandbox-1');
+    expect(table.count('sandbox-1')).toBe(0);
+    const reservation = table.reserveStreaming('sandbox-1');
+    table.cancelStreamingReservation('sandbox-1', reservation);
+    expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('owns failed streaming cleanup until a legitimate reap succeeds', async () => {
+    const stop = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('signal failed'))
+      .mockResolvedValueOnce(undefined);
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const id = await table.createStreaming({
+      ...args(executor),
+      onEvent: async () => {},
+      onEnd: vi.fn(),
+    });
+
+    await expect(
+      table.closeStreaming('sandbox-1', id, { runnable: true }),
+    ).resolves.toBeUndefined();
+    expect(stop).toHaveBeenCalledTimes(2);
+    expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('keeps cold streaming cleanup deferred until a legitimate reap', async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const id = await table.createStreaming({
+      ...args(executor),
+      onEvent: async () => {},
+      onEnd: vi.fn(),
+    });
+
+    await table.closeStreaming('sandbox-1', id, { runnable: false });
+    expect(stop).not.toHaveBeenCalled();
+    expect(table.count('sandbox-1')).toBe(1);
+
+    await table.reapDeferred('sandbox-1');
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(table.count('sandbox-1')).toBe(0);
+  });
+
+  it('ends every streaming route before shutdown waits for physical stops', async () => {
+    const secondStop = deferred<void>();
+    const stop = vi
+      .fn<() => Promise<void>>()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(() => secondStop.promise);
+    const onEnd = vi.fn();
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    await table.createStreaming({
+      ...args(executor),
+      onEvent: async () => {},
+      onEnd,
+    });
+
+    table.disposeSandbox('sandbox-1');
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onEnd.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    expect(table.count('sandbox-1')).toBe(0);
+
+    const shutdownEnd = vi.fn();
+    await table.createStreaming({
+      ...args(executor),
+      onEvent: async () => {},
+      onEnd: shutdownEnd,
+    });
+    const pendingEnd = vi.fn();
+    await table.createStreaming({
+      ...args(executor),
+      path: '/home/user/other',
+      onEvent: async () => {},
+      onEnd: pendingEnd,
+    });
+
+    const shutdown = table.shutdown();
+    expect(shutdownEnd).toHaveBeenCalledTimes(1);
+    expect(pendingEnd).toHaveBeenCalledTimes(1);
+    expect(stop).toHaveBeenCalledTimes(2);
+    secondStop.resolve();
+    await shutdown;
+  });
+
+  it('drops an operation binding when container death makes its watcher unrecoverable', async () => {
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop: async () => {} }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+    const operationId = '66666666-6666-4666-8666-666666666666';
+    const before = await table.create({ ...args(executor), operationId });
+
+    table.disposeSandbox('sandbox-1');
+    const after = await table.create({ ...args(executor), operationId });
+
+    expect(after).not.toBe(before);
+    expect(executor.watchDir).toHaveBeenCalledTimes(2);
   });
 
   it('keeps watcher IDs scoped to their sandbox', async () => {

--- a/packages/server/src/e2b/watcher-table.ts
+++ b/packages/server/src/e2b/watcher-table.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { resolveSandboxPath } from '@dormice/shared';
 import type {
   Executor,
   WatchDirHandle,
@@ -6,76 +7,377 @@ import type {
 } from '../executor/executor';
 
 /**
- * The polling half of directory watching — what the sync SDKs use instead
- * of the WatchDir stream: CreateWatcher parks a watcher here, GetWatcherEvents
- * drains its buffer, RemoveWatcher retires it. Daemon memory, like the process
- * table: a daemon restart empties it honestly, and a watcher's death (its
- * container stopping) deletes its record through physical conduction — the
- * next poll answers not_found, no lifecycle hooks involved.
+ * The daemon-owned half of directory watching. Polling watchers publish an ID
+ * whose event buffer can be drained; streaming watchers attach their delivery
+ * callback directly. Both kinds park their physical handle here so request
+ * teardown, natural process exit, sandbox lifecycle, and daemon shutdown all
+ * converge through one owner.
  *
  * Two ceilings real envd does not have, on purpose: envd runs inside the
- * sandbox, so its unbounded buffer can only blow up the sandbox itself —
- * this table lives in the host-side daemon, where unbounded means one
- * sandbox writing files in a loop grows the host's memory. The buffer keeps
- * the newest events (oldest dropped first); the per-sandbox watcher count
- * refuses with resource_exhausted. Starting and retired records count too:
- * reservations make the ceiling true under concurrent creates, and retired
- * handles still own a physical process until the next legitimate wake reaps it.
+ * sandbox, so its unbounded state can only blow up the sandbox itself — this
+ * registry lives in the host-side daemon. Starting and retired records count
+ * too: reservations make the watcher ceiling true under concurrent starts,
+ * and retired handles still own a physical process until a legitimate wake
+ * reaps them.
  */
 export const MAX_EVENTS_PER_WATCHER = 8192;
 export const MAX_WATCHERS_PER_SANDBOX = 128;
 
-/** Refused watcher creation: the per-sandbox ceiling. */
+/** Five minutes comfortably covers a bounded client retry sequence. */
+export const WATCHER_OPERATION_RETENTION_MS = 5 * 60 * 1000;
+/** Live bindings plus completed tombstones; live bindings are never evicted. */
+export const MAX_WATCHER_OPERATIONS_PER_SANDBOX = 256;
+
+/** Refused watcher creation: the per-sandbox physical watcher ceiling. */
 export class WatcherLimitError extends Error {}
+/** Refused opt-in create: its bounded operation ledger is full. */
+export class WatcherOperationLimitError extends Error {}
+/** The same operation identity was reused for a different canonical request. */
+export class WatcherOperationConflictError extends Error {}
+
+interface OperationIdentity {
+  id: string;
+  fingerprint: string;
+}
 
 interface WatcherRecord {
   watcherId: string;
   sandboxId: string;
+  kind: 'polling' | 'streaming';
   events: WatchEvent[];
   state: 'starting' | 'active' | 'retired' | 'ended';
+  operation?: OperationIdentity;
+  published: boolean;
   handle?: WatchDirHandle;
   endError?: Error;
+  startPromise?: Promise<string>;
   stopPromise?: Promise<void>;
+  streamEnd?: (error?: Error) => void;
+  streamEndNotified?: boolean;
+}
+
+interface OperationTombstone extends OperationIdentity {
+  kind: 'tombstone';
+  sandboxId: string;
+  watcherId: string;
+  expiresAt: number;
+}
+
+type OperationEntry =
+  | { kind: 'live'; record: WatcherRecord }
+  | OperationTombstone;
+
+export interface WatcherTableOptions {
+  now?: () => number;
+  operationRetentionMs?: number;
+  maxOperationsPerSandbox?: number;
+  retryDelay?: (milliseconds: number) => Promise<void>;
+}
+
+interface CreateArgs {
+  executor: Executor;
+  sandboxId: string;
+  path: string;
+  recursive: boolean;
+  operationId?: string;
+}
+
+interface CreateStreamingArgs extends Omit<CreateArgs, 'operationId'> {
+  reservationId?: string;
+  onEvent: (event: WatchEvent) => void | Promise<void>;
+  onEnd(error?: Error): void;
 }
 
 export class WatcherTable {
   private readonly records = new Map<string, WatcherRecord>();
+  private readonly operations = new Map<string, OperationEntry>();
+  private readonly now: () => number;
+  private readonly operationRetentionMs: number;
+  private readonly maxOperationsPerSandbox: number;
+  private readonly retryDelay: (milliseconds: number) => Promise<void>;
+  private closed = false;
 
-  /** Starts a watcher, reserving capacity before the executor can yield. */
-  async create(args: {
-    executor: Executor;
-    sandboxId: string;
-    path: string;
-    recursive: boolean;
-  }): Promise<string> {
-    const { executor, sandboxId, path, recursive } = args;
+  constructor(opts: WatcherTableOptions = {}) {
+    this.now = opts.now ?? Date.now;
+    this.operationRetentionMs =
+      opts.operationRetentionMs ?? WATCHER_OPERATION_RETENTION_MS;
+    this.maxOperationsPerSandbox =
+      opts.maxOperationsPerSandbox ?? MAX_WATCHER_OPERATIONS_PER_SANDBOX;
+    this.retryDelay =
+      opts.retryDelay ??
+      ((milliseconds) =>
+        new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+  }
+
+  /**
+   * Starts a polling watcher. An optional Dormice operation ID makes the
+   * result replay-safe without changing official envd's protobuf message.
+   */
+  async create(args: CreateArgs): Promise<string> {
+    this.pruneOperations();
+    const operation = args.operationId
+      ? {
+          id: args.operationId,
+          fingerprint: this.fingerprint(args.path, args.recursive),
+        }
+      : undefined;
+
+    if (operation) {
+      const existing = this.operations.get(
+        this.operationKey(args.sandboxId, operation.id),
+      );
+      if (existing) return this.replay(existing, operation);
+      if (this.operationCount(args.sandboxId) >= this.maxOperationsPerSandbox) {
+        throw new WatcherOperationLimitError(
+          `sandbox ${args.sandboxId} already has ${this.maxOperationsPerSandbox} retained watcher operations — retry after the replay window expires`,
+        );
+      }
+    }
+
+    const record = this.reserve(args.sandboxId, 'polling', operation);
+    const started = this.start(record, args, (event) => {
+      if (record.state !== 'starting' && record.state !== 'active') return;
+      record.events.push(event);
+      if (record.events.length > MAX_EVENTS_PER_WATCHER) {
+        record.events.shift();
+      }
+    });
+    record.startPromise = started;
+    return started;
+  }
+
+  /** Reserves one registry slot for a streaming watcher before physical start. */
+  reserveStreaming(sandboxId: string): string {
+    return this.reserve(sandboxId, 'streaming').watcherId;
+  }
+
+  /** Releases an unpublished streaming reservation after wake/start refusal. */
+  cancelStreamingReservation(sandboxId: string, watcherId: string): void {
+    const record = this.records.get(watcherId);
+    if (
+      record?.sandboxId === sandboxId &&
+      record.kind === 'streaming' &&
+      record.state === 'starting' &&
+      !record.published
+    ) {
+      this.finalize(record);
+    }
+  }
+
+  /** Starts a streaming watcher under the same capacity and cleanup owner. */
+  async createStreaming(args: CreateStreamingArgs): Promise<string> {
+    const reserved = args.reservationId
+      ? this.records.get(args.reservationId)
+      : undefined;
+    if (
+      args.reservationId &&
+      (!reserved ||
+        reserved.sandboxId !== args.sandboxId ||
+        reserved.kind !== 'streaming' ||
+        reserved.state !== 'starting')
+    ) {
+      throw new Error(
+        `streaming watcher reservation ${args.reservationId} is not live`,
+      );
+    }
+    const record = reserved ?? this.reserve(args.sandboxId, 'streaming');
+    record.streamEnd = args.onEnd;
+    const started = this.start(record, args, async (event) => {
+      if (record.state !== 'starting' && record.state !== 'active') return;
+      await args.onEvent(event);
+    });
+    record.startPromise = started;
+    return started;
+  }
+
+  /** Living, published polling events; every other ID reads as absent. */
+  drain(sandboxId: string, watcherId: string): WatchEvent[] | undefined {
+    const record = this.records.get(watcherId);
+    if (
+      !record ||
+      record.sandboxId !== sandboxId ||
+      record.kind !== 'polling' ||
+      record.state !== 'active'
+    ) {
+      return undefined;
+    }
+    return record.events.splice(0, record.events.length);
+  }
+
+  /**
+   * Makes one well-formed watcher ID absent from this sandbox. Unknown and
+   * cross-sandbox IDs already satisfy that goal and deliberately look alike.
+   * A cold sandbox retires without touching its container.
+   */
+  async removeGoal(
+    sandboxId: string,
+    watcherId: string,
+    opts: { runnable: boolean; attempts?: number } = { runnable: true },
+  ): Promise<void> {
+    const record = this.records.get(watcherId);
+    if (!record || record.sandboxId !== sandboxId) return;
+    record.state = 'retired';
+    record.events.length = 0;
+    if (!opts.runnable) return;
+
+    const attempts = Math.max(1, opts.attempts ?? 1);
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        await this.stopRetired(record);
+        return;
+      } catch (error) {
+        if (attempt === attempts || !this.records.has(record.watcherId)) {
+          throw error;
+        }
+        await this.retryDelay(Math.min(25 * 2 ** (attempt - 1), 100));
+      }
+    }
+  }
+
+  /** Backward-compatible spelling for existing callers and focused tests. */
+  async remove(sandboxId: string, watcherId: string): Promise<boolean> {
+    const record = this.records.get(watcherId);
+    if (!record || record.sandboxId !== sandboxId) return false;
+    await this.removeGoal(sandboxId, watcherId, { runnable: true });
+    return true;
+  }
+
+  /** Retires without touching the container; a legitimate wake reaps it. */
+  retire(sandboxId: string, watcherId: string): boolean {
+    const record = this.records.get(watcherId);
+    if (!record || record.sandboxId !== sandboxId) return false;
+    record.state = 'retired';
+    record.events.length = 0;
+    return true;
+  }
+
+  /** Reaps all deferred polling and streaming cleanup after a legitimate wake. */
+  async reapDeferred(sandboxId: string): Promise<void> {
+    const retired = [...this.records.values()].filter(
+      (record) => record.sandboxId === sandboxId && record.state === 'retired',
+    );
+    for (const record of retired) {
+      try {
+        await this.stopRetired(record);
+      } catch {
+        // Cleanup is subordinate to the user work that caused this wake. The
+        // record stays retired and the next legitimate wake retries it.
+      }
+    }
+  }
+
+  /** Backward-compatible name while lifecycle call sites migrate. */
+  reapRetired(sandboxId: string): Promise<void> {
+    return this.reapDeferred(sandboxId);
+  }
+
+  /** A proven container stop/destroy ends every watcher without signaling it. */
+  disposeSandbox(sandboxId: string): void {
+    for (const record of [...this.records.values()]) {
+      if (record.sandboxId !== sandboxId) continue;
+      this.notifyStreamEnd(record, new Error('sandbox container ended'));
+      this.finalize(record, false);
+    }
+  }
+
+  /** Stops a route-owned streaming watcher while retaining failed cleanup. */
+  closeStreaming(
+    sandboxId: string,
+    watcherId: string,
+    opts: { runnable: boolean },
+  ): Promise<void> {
+    return this.removeGoal(sandboxId, watcherId, {
+      runnable: opts.runnable,
+      attempts: opts.runnable ? 3 : 1,
+    });
+  }
+
+  /** Bounded best-effort teardown for Fastify/daemon shutdown. */
+  async shutdown(timeoutMs = 5000): Promise<void> {
+    this.closed = true;
+    const records = [...this.records.values()];
+    for (const record of records) {
+      record.state = 'retired';
+      record.events.length = 0;
+      this.notifyStreamEnd(record);
+    }
+    const stopping = Promise.allSettled(
+      records.map((record) => this.stopRetired(record)),
+    );
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      stopping,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    for (const record of records) this.finalize(record);
+  }
+
+  count(sandboxId: string): number {
+    let count = 0;
+    for (const record of this.records.values()) {
+      if (record.sandboxId === sandboxId && record.state !== 'ended') count++;
+    }
+    return count;
+  }
+
+  operationCount(sandboxId: string): number {
+    this.pruneOperations();
+    let count = 0;
+    for (const entry of this.operations.values()) {
+      const owner =
+        entry.kind === 'live' ? entry.record.sandboxId : entry.sandboxId;
+      if (owner === sandboxId) count++;
+    }
+    return count;
+  }
+
+  private reserve(
+    sandboxId: string,
+    kind: WatcherRecord['kind'],
+    operation?: OperationIdentity,
+  ): WatcherRecord {
+    if (this.closed) throw new Error('watcher registry is shutting down');
     if (this.count(sandboxId) >= MAX_WATCHERS_PER_SANDBOX) {
       throw new WatcherLimitError(
         `sandbox ${sandboxId} already has ${MAX_WATCHERS_PER_SANDBOX} watchers — remove some before creating more`,
       );
     }
-
     const record: WatcherRecord = {
       watcherId: randomUUID(),
       sandboxId,
+      kind,
       events: [],
       state: 'starting',
+      operation,
+      published: false,
     };
     this.records.set(record.watcherId, record);
+    if (operation) {
+      this.operations.set(this.operationKey(sandboxId, operation.id), {
+        kind: 'live',
+        record,
+      });
+    }
+    return record;
+  }
 
+  private async start(
+    record: WatcherRecord,
+    args: Omit<CreateArgs, 'operationId'>,
+    onEvent: (event: WatchEvent) => void | Promise<void>,
+  ): Promise<string> {
     try {
-      const handle = await executor.watchDir(sandboxId, {
-        path,
-        recursive,
-        onEvent: (event) => {
-          if (record.state !== 'starting' && record.state !== 'active') return;
-          record.events.push(event);
-          if (record.events.length > MAX_EVENTS_PER_WATCHER) {
-            record.events.shift();
-          }
-        },
+      const handle = await args.executor.watchDir(args.sandboxId, {
+        path: resolveSandboxPath(args.path),
+        recursive: args.recursive,
+        onEvent,
         onEnd: (error) => {
           record.endError = error;
+          const published = record.published;
+          if (published) this.notifyStreamEnd(record, error);
           this.finalize(record);
         },
       });
@@ -88,6 +390,7 @@ export class WatcherTable {
         throw failure;
       }
       record.state = 'active';
+      record.published = true;
       return record.watcherId;
     } catch (error) {
       this.finalize(record);
@@ -95,62 +398,25 @@ export class WatcherTable {
     }
   }
 
-  /** Living, published watcher events; retired/starting IDs read as absent. */
-  drain(sandboxId: string, watcherId: string): WatchEvent[] | undefined {
-    const record = this.records.get(watcherId);
-    if (
-      !record ||
-      record.sandboxId !== sandboxId ||
-      record.state !== 'active'
-    ) {
-      return undefined;
+  private replay(
+    existing: OperationEntry,
+    operation: OperationIdentity,
+  ): Promise<string> {
+    const fingerprint =
+      existing.kind === 'live'
+        ? existing.record.operation?.fingerprint
+        : existing.fingerprint;
+    if (fingerprint !== operation.fingerprint) {
+      throw new WatcherOperationConflictError(
+        `watcher operation ${operation.id} was already used with different path or options`,
+      );
     }
-    return record.events.splice(0, record.events.length);
-  }
-
-  /**
-   * Retires without touching the container. Frozen cleanup stays cold; the
-   * next real wake calls reapRetired before serving user work.
-   */
-  retire(sandboxId: string, watcherId: string): boolean {
-    const record = this.records.get(watcherId);
-    if (!record || record.sandboxId !== sandboxId) return false;
-    record.state = 'retired';
-    record.events.length = 0;
-    return true;
-  }
-
-  /** Stops now. A failed stop remains retired so the next wake can retry. */
-  async remove(sandboxId: string, watcherId: string): Promise<boolean> {
-    const record = this.records.get(watcherId);
-    if (!record || record.sandboxId !== sandboxId) return false;
-    record.state = 'retired';
-    record.events.length = 0;
-    await this.stopRetired(record);
-    return true;
-  }
-
-  /** Reaps deferred frozen cleanup after a legitimate wake made it runnable. */
-  async reapRetired(sandboxId: string): Promise<void> {
-    const retired = [...this.records.values()].filter(
-      (record) => record.sandboxId === sandboxId && record.state === 'retired',
+    if (existing.kind === 'tombstone') {
+      return Promise.resolve(existing.watcherId);
+    }
+    return (
+      existing.record.startPromise ?? Promise.resolve(existing.record.watcherId)
     );
-    for (const record of retired) {
-      try {
-        await this.stopRetired(record);
-      } catch {
-        // Cleanup is subordinate to the user work that caused this wake.
-        // The record stays retired and the next legitimate wake retries it.
-      }
-    }
-  }
-
-  count(sandboxId: string): number {
-    let count = 0;
-    for (const record of this.records.values()) {
-      if (record.sandboxId === sandboxId && record.state !== 'ended') count++;
-    }
-    return count;
   }
 
   private async stopRetired(record: WatcherRecord): Promise<void> {
@@ -158,21 +424,61 @@ export class WatcherTable {
     const handle = record.handle;
     if (!handle) return;
     if (!record.stopPromise) {
-      record.stopPromise = handle.stop().then(
+      const attempt = handle.stop().then(
         () => this.finalize(record),
         (error) => {
-          record.stopPromise = undefined;
+          if (record.stopPromise === attempt) record.stopPromise = undefined;
           throw error;
         },
       );
+      record.stopPromise = attempt;
     }
     await record.stopPromise;
   }
 
-  private finalize(record: WatcherRecord): void {
+  private notifyStreamEnd(record: WatcherRecord, error?: Error): void {
+    if (record.kind !== 'streaming' || record.streamEndNotified) return;
+    record.streamEndNotified = true;
+    record.streamEnd?.(error);
+  }
+
+  private finalize(record: WatcherRecord, retainOperation = true): void {
     if (record.state === 'ended') return;
     record.state = 'ended';
     this.records.delete(record.watcherId);
     record.events.length = 0;
+    if (!record.operation) return;
+
+    const key = this.operationKey(record.sandboxId, record.operation.id);
+    const entry = this.operations.get(key);
+    if (entry?.kind !== 'live' || entry.record !== record) return;
+    if (!record.published || !retainOperation) {
+      this.operations.delete(key);
+      return;
+    }
+    this.operations.set(key, {
+      kind: 'tombstone',
+      sandboxId: record.sandboxId,
+      watcherId: record.watcherId,
+      ...record.operation,
+      expiresAt: this.now() + this.operationRetentionMs,
+    });
+  }
+
+  private pruneOperations(): void {
+    const now = this.now();
+    for (const [key, entry] of this.operations) {
+      if (entry.kind === 'tombstone' && entry.expiresAt <= now) {
+        this.operations.delete(key);
+      }
+    }
+  }
+
+  private fingerprint(path: string, recursive: boolean): string {
+    return JSON.stringify([resolveSandboxPath(path), recursive]);
+  }
+
+  private operationKey(sandboxId: string, operationId: string): string {
+    return `${sandboxId}\0${operationId}`;
   }
 }

--- a/packages/server/src/lifecycle.ts
+++ b/packages/server/src/lifecycle.ts
@@ -57,8 +57,10 @@ export async function stopSandbox(
   sandboxId: string,
   cause?: string,
   actor?: string | null,
+  watchers?: WatcherTable,
 ): Promise<SandboxRow> {
   await executor.stop(sandboxId);
+  watchers?.disposeSandbox(sandboxId);
   const row = transition(db, sandboxId, 'stopped');
   recordActivity(db, {
     kind: 'stopped',
@@ -96,6 +98,7 @@ export async function destroySandbox(
     kind: 'destroyed',
     cause: 'via destroySandbox',
   },
+  watchers?: WatcherTable,
 ): Promise<void> {
   const row = findById(db, sandboxId);
   if (row?.state === 'archived') {
@@ -105,6 +108,7 @@ export async function destroySandbox(
       );
     }
     await store.delete(objectKey(sandboxId));
+    watchers?.disposeSandbox(sandboxId);
     deleteSandbox(db, sandboxId);
     // With the disk gone its metrics history has no owner; fleet snapshots
     // belong to no sandbox and stay.
@@ -119,6 +123,7 @@ export async function destroySandbox(
     return;
   }
   await executor.destroy(sandboxId);
+  watchers?.disposeSandbox(sandboxId);
   deleteSandbox(db, sandboxId);
   deleteSandboxMetricsSamples(db, sandboxId);
   if (row) {
@@ -149,8 +154,10 @@ export async function rebuildSandbox(
   row: SandboxRow,
   actor?: string | null,
   detail?: string,
+  watchers?: WatcherTable,
 ): Promise<SandboxRow> {
   await executor.removeContainer(row.id);
+  watchers?.disposeSandbox(row.id);
   recordActivity(db, {
     kind: 'rebuilt',
     sandboxName: row.name,
@@ -196,7 +203,7 @@ export async function wakeSandbox(
 ): Promise<SandboxRow> {
   switch (row.state) {
     case 'active':
-      await watchers?.reapRetired(row.id);
+      await watchers?.reapDeferred(row.id);
       return row;
     case 'frozen':
     case 'stopped': {
@@ -210,11 +217,12 @@ export async function wakeSandbox(
               row,
               actor,
               `stale shell swapped at wake: ${born} -> ${next}`,
+              watchers,
             )
           : row;
       if (fresh.state === 'frozen') {
         await executor.unfreeze(fresh.id);
-        await watchers?.reapRetired(fresh.id);
+        await watchers?.reapDeferred(fresh.id);
         return awaken(
           db,
           fresh,
@@ -227,7 +235,7 @@ export async function wakeSandbox(
       await executor.start(fresh.id, {
         image: resolveImage(db, fresh.template),
       });
-      await watchers?.reapRetired(fresh.id);
+      await watchers?.reapDeferred(fresh.id);
       return awaken(db, fresh, 'cold start from the surviving disk', actor);
     }
     case 'archived':

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -11,6 +11,7 @@ import { migrateDb, openDb } from './db/db';
 import { listSandboxes } from './db/ledger';
 import { acquireSingleWriterLock } from './db/lock';
 import { ensureRuntimeSettings, readRuntimeSettings } from './db/settings';
+import { WatcherTable } from './e2b/watcher-table';
 import { DockerExecutor } from './executor/docker';
 import type { Executor } from './executor/executor';
 import { FakeExecutor } from './executor/fake';
@@ -93,6 +94,7 @@ const executor = buildExecutor(config, (msg) => log.info(msg));
 // One queue for the whole daemon: HTTP verbs and the heartbeat's actors
 // must share the same per-sandbox slots or the serialization means nothing.
 const locks = new KeyedQueue();
+const watchers = new WatcherTable();
 
 // The archiver exists exactly when S3 is configured; without it the daemon
 // is byte-for-byte the archive-less daemon. Temp transfers stage next to
@@ -107,6 +109,7 @@ if (s3 !== null) {
     store: new S3Store(s3),
     tmpDir: path.join(config.DORMICE_DATA_DIR, 'tmp'),
     log: (msg) => log.info(msg),
+    watchers,
   });
   await archiver.init();
   log.info(`archiver enabled: bucket ${s3.bucket} at ${s3.endpoint}`);
@@ -195,6 +198,7 @@ const app = buildApp({
   ingress,
   swap,
   updater,
+  watchers,
 });
 
 // Before trusting the pairing of this ledger and this reality, check it:
@@ -217,7 +221,14 @@ if (refusal !== null) {
 // should not pretend to manage it. The archiver's restore tracker is empty
 // at boot, so this pass is also what repairs restoring zombies — before
 // listen, so no request ever observes one.
-const repaired = await reconcile(db, executor, locks, undefined, archiver);
+const repaired = await reconcile(
+  db,
+  executor,
+  locks,
+  undefined,
+  archiver,
+  watchers,
+);
 app.log.info(repaired, 'startup reconcile');
 recordActivity(db, {
   kind: 'daemon-started',
@@ -231,6 +242,32 @@ recordActivity(db, {
 // not configurable — a knob would be one typo away from 0.0.0.0. Exposing
 // the daemon to the outside world is a reverse proxy's job.
 await app.listen({ host: '127.0.0.1', port: config.DORMICE_PORT });
+
+// systemd stops the daemon with SIGTERM. Route both terminal signals through
+// Fastify so preClose can end long-lived streams and reap watcher ownership
+// before Node exits. The first signal owns shutdown; a second one still has
+// the platform's default behavior instead of leaving a wedged process forever.
+let closing = false;
+let heartbeatTimer: NodeJS.Timeout | undefined;
+let metricsTimer: NodeJS.Timeout | undefined;
+const close = async (signal: NodeJS.Signals) => {
+  if (closing) return;
+  closing = true;
+  process.removeListener('SIGTERM', onSigterm);
+  process.removeListener('SIGINT', onSigint);
+  clearTimeout(heartbeatTimer);
+  clearTimeout(metricsTimer);
+  try {
+    await app.close();
+  } catch (error) {
+    app.log.error(error, `graceful shutdown after ${signal} failed`);
+    process.exitCode = 1;
+  }
+};
+const onSigterm = () => void close('SIGTERM');
+const onSigint = () => void close('SIGINT');
+process.once('SIGTERM', onSigterm);
+process.once('SIGINT', onSigint);
 
 // The daemon's heartbeat: reconcile, then scan. Reconciling every tick is
 // what keeps the ledger honest while the daemon runs — a sandbox whose
@@ -249,7 +286,14 @@ await app.listen({ host: '127.0.0.1', port: config.DORMICE_PORT });
 let suspects: ReadonlySet<string> = new Set();
 async function tick() {
   try {
-    const drift = await reconcile(db, executor, locks, suspects, archiver);
+    const drift = await reconcile(
+      db,
+      executor,
+      locks,
+      suspects,
+      archiver,
+      watchers,
+    );
     suspects = new Set(drift.suspects);
     if (
       drift.repairedStates +
@@ -261,17 +305,29 @@ async function tick() {
     ) {
       app.log.warn(drift, 'runtime reconcile repaired drift');
     }
-    const scan = await scanOnce(db, executor, locks, new Date(), archiver);
+    const scan = await scanOnce(
+      db,
+      executor,
+      locks,
+      new Date(),
+      archiver,
+      watchers,
+    );
     for (const failure of scan.failures) {
       app.log.error(failure, 'idle scan: sandbox transition failed');
     }
   } catch (error) {
     app.log.error(error, 'heartbeat tick failed');
   } finally {
-    setTimeout(tick, config.DORMICE_SCAN_INTERVAL_SECONDS * 1000);
+    if (!closing) {
+      heartbeatTimer = setTimeout(
+        tick,
+        config.DORMICE_SCAN_INTERVAL_SECONDS * 1000,
+      );
+    }
   }
 }
-setTimeout(tick, config.DORMICE_SCAN_INTERVAL_SECONDS * 1000);
+heartbeatTimer = setTimeout(tick, config.DORMICE_SCAN_INTERVAL_SECONDS * 1000);
 
 // The metrics sampler's own chained ticker — deliberately not a passenger
 // on the heartbeat, whose ticks legitimately run 45s+ (memory.reclaim) and
@@ -296,10 +352,12 @@ async function metricsTick() {
   } catch (error) {
     app.log.error(error, 'metrics sampler tick failed');
   } finally {
-    setTimeout(
-      metricsTick,
-      config.DORMICE_METRICS_SAMPLE_INTERVAL_SECONDS * 1000,
-    );
+    if (!closing) {
+      metricsTimer = setTimeout(
+        metricsTick,
+        config.DORMICE_METRICS_SAMPLE_INTERVAL_SECONDS * 1000,
+      );
+    }
   }
 }
-setTimeout(metricsTick, 0);
+metricsTimer = setTimeout(metricsTick, 0);

--- a/packages/server/src/reconciler.test.ts
+++ b/packages/server/src/reconciler.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { type Db, migrateDb, openDb } from './db/db';
 import { createSandbox, findByName, transition } from './db/ledger';
 import type { SandboxRow } from './db/schema';
+import { WatcherTable } from './e2b/watcher-table';
 import { FakeExecutor } from './executor/fake';
 import { KeyedQueue } from './keyed-queue';
 import { reconcile } from './reconciler';
@@ -66,17 +67,32 @@ describe('startup reconcile', () => {
     expect(findByName(db, 'alice')?.state).toBe('frozen');
   });
 
-  it('repairs across rungs the transition table would forbid', async () => {
+  it('repairs across rungs and drops ownership when reality is stopped', async () => {
     const { db, executor, locks } = setup();
     // Ledger says active, container is fully stopped — a two-rung gap that
     // transition() would reject. The reconciler records facts, not moves.
     const row = await seed(db, executor, 'alice');
+    const watchers = new WatcherTable();
+    await watchers.create({
+      executor,
+      sandboxId: row.id,
+      path: '/home/user',
+      recursive: false,
+    });
     await executor.freeze(row.id);
     await executor.stop(row.id);
 
-    const result = await reconcile(db, executor, locks);
+    const result = await reconcile(
+      db,
+      executor,
+      locks,
+      undefined,
+      undefined,
+      watchers,
+    );
     expect(result).toEqual({ ...NONE, repairedStates: 1 });
     expect(findByName(db, 'alice')?.state).toBe('stopped');
+    expect(watchers.count(row.id)).toBe(0);
   });
 
   it('keeps the row of a pruned container: the disk is the sandbox', async () => {

--- a/packages/server/src/reconciler.ts
+++ b/packages/server/src/reconciler.ts
@@ -8,6 +8,7 @@ import {
   overwriteState,
 } from './db/ledger';
 import type { SandboxRow } from './db/schema';
+import type { WatcherTable } from './e2b/watcher-table';
 import type { ContainerState, Executor } from './executor/executor';
 import type { KeyedQueue } from './keyed-queue';
 
@@ -98,6 +99,7 @@ export async function reconcile(
   locks: KeyedQueue,
   priorSuspects?: ReadonlySet<string>,
   archiver?: { hasLiveRestore(sandboxId: string): boolean },
+  watchers?: WatcherTable,
 ): Promise<ReconcileResult> {
   const rows = listSandboxes(db);
   const containers = await executor.listContainers();
@@ -191,6 +193,7 @@ export async function reconcile(
       owners.add(row.id);
       if (LEDGER_STATE[observed] !== row.state) {
         await repairUnderLock(row, () => {
+          if (observed === 'stopped') watchers?.disposeSandbox(row.id);
           overwriteState(db, row.id, LEDGER_STATE[observed]);
           result.repairedStates += 1;
           note(
@@ -203,6 +206,7 @@ export async function reconcile(
       owners.add(row.id);
       if (row.state !== 'stopped') {
         await repairUnderLock(row, () => {
+          watchers?.disposeSandbox(row.id);
           overwriteState(db, row.id, 'stopped');
           result.repairedStates += 1;
           note(
@@ -213,6 +217,7 @@ export async function reconcile(
       }
     } else {
       await repairUnderLock(row, () => {
+        watchers?.disposeSandbox(row.id);
         deleteSandbox(db, row.id);
         result.deletedRows += 1;
         note(row, 'container and disk both gone — row deleted, key freed');

--- a/packages/server/src/routes/sandboxes.ts
+++ b/packages/server/src/routes/sandboxes.ts
@@ -721,7 +721,14 @@ export const sandboxRoutes: FastifyPluginAsyncZod<
             `sandbox "${name}" is ${existing.state} — it has no container to rebuild`,
           );
         }
-        const row = await rebuildSandbox(db, executor, existing, request.actor);
+        const row = await rebuildSandbox(
+          db,
+          executor,
+          existing,
+          request.actor,
+          undefined,
+          watchers,
+        );
         return { sandbox: toSandbox(row, endpoint) };
       });
     },
@@ -902,6 +909,7 @@ export const sandboxRoutes: FastifyPluginAsyncZod<
             cause: 'via destroySandbox',
             actor: request.actor,
           },
+          watchers,
         );
         return { destroyed: true };
       });

--- a/packages/server/src/scanner.ts
+++ b/packages/server/src/scanner.ts
@@ -2,6 +2,7 @@ import type { Archiver } from './archive/archiver';
 import type { Db } from './db/db';
 import { findById, listSandboxes } from './db/ledger';
 import type { SandboxRow } from './db/schema';
+import type { WatcherTable } from './e2b/watcher-table';
 import type { Executor } from './executor/executor';
 import type { KeyedQueue } from './keyed-queue';
 import { destroySandbox, freezeSandbox, stopSandbox } from './lifecycle';
@@ -110,6 +111,7 @@ export async function scanOnce(
   locks: KeyedQueue,
   now: Date,
   archiver?: Archiver,
+  watchers?: WatcherTable,
 ): Promise<ScanResult> {
   const result: ScanResult = {
     frozen: 0,
@@ -143,6 +145,7 @@ export async function scanOnce(
             fresh.id,
             archiver?.store ?? null,
             { kind: 'expired-killed', cause: 'E2B deadline (kill) reached' },
+            watchers,
           );
           result.expiredKilled += 1;
           return;
@@ -172,6 +175,8 @@ export async function scanOnce(
             executor,
             fresh.id,
             `idle ${fresh.stopAfterSeconds}s reached — container torn down, disk kept (scanner)`,
+            undefined,
+            watchers,
           );
           result.stopped += 1;
         }

--- a/website/content/docs/e2b-differences.mdx
+++ b/website/content/docs/e2b-differences.mdx
@@ -26,7 +26,7 @@ daemon:
 | `uploadUrl()` / `downloadUrl()` | signed URLs: expiry enforced, a tampered signature is a 401; CORS-open, so a browser can POST/GET them directly — with `DORMICE_SANDBOX_DOMAIN` set, E2B's `49983-<sandboxId>.<domain>/files` form works too |
 | Range requests on downloads | single-range `Range: bytes=…` gets a `206` with `content-range`; downloads advertise `accept-ranges: bytes` — so `<video>` streams and seeks instead of downloading the whole file, and interrupted downloads resume |
 | `files.list` / `exists` / `makeDir` / `rename` / `remove` | typed errors match the SDK's expectations |
-| `files.watchDir` | streamed events, and the polling watcher API the Python sync SDK uses |
+| `files.watchDir` | streamed events, and the polling watcher API the Python sync SDK uses; failed cleanup stays daemon-owned until it converges |
 | `getHost(port)` | port proxy with wake-on-traffic (set `DORMICE_SANDBOX_DOMAIN`) |
 | `getMetrics()` | one live sample; observing never wakes a frozen sandbox |
 | Templates by name | `Sandbox.create('name')` resolves a registered template; an unregistered name is an honest 404 |
@@ -46,6 +46,16 @@ daemon:
 - **`metadata.name`** turns `Sandbox.create` into Dormice's
   idempotent acquire — see
   [Using the official E2B SDKs](/docs/e2b-sdks).
+- **Replay-safe polling watches are opt-in.** `CreateWatcher` accepts the
+  Dormice extension header `x-dormice-watcher-operation-id` with a UUID.
+  Within one sandbox, reusing it with the same normalized path and
+  `recursive` value returns the original watcher ID; changing either is a
+  `409`. The binding lives as long as its watcher, then for a bounded
+  five-minute replay window. The header is outside the protobuf message,
+  so official SDKs remain wire-compatible and keep their native behavior.
+  `RemoveWatcher` is a goal-state operation: any well-formed ID succeeds
+  once it is absent, including retries after cleanup. A daemon restart
+  clears this in-memory identity state, like the process and watcher tables.
 - **One domain, not one subdomain per sandbox.** The SDK addresses
   sandboxes through a header on a single endpoint, so no wildcard DNS is
   needed for the API itself — only `getHost()` preview URLs want a

--- a/website/content/docs/upgrading.mdx
+++ b/website/content/docs/upgrading.mdx
@@ -40,12 +40,13 @@ the repo.
   listening it reconciles its records against what Docker actually
   shows, so restarting it is always safe.
 
-Two footnotes. The E2B process and watcher tables live in daemon
-memory: processes started over that surface keep running inside their
-containers across a restart, but the fresh daemon no longer lists them
-([details](/docs/e2b-differences)). And the pinned toolchain (Node,
-gVisor) is only *installed* when missing — an already-present gVisor is
-kept as-is, not upgraded.
+Two footnotes. The E2B process and watcher registries live in daemon
+memory: processes and in-container watcher processes may outlive a hard
+daemon crash, but the fresh daemon no longer lists or controls those old
+handles; normal graceful shutdown first makes a bounded best-effort
+cleanup pass ([details](/docs/e2b-differences)). And the pinned toolchain
+(Node, gVisor) is only *installed* when missing — an already-present
+gVisor is kept as-is, not upgraded.
 
 ## Upgrade sandbox images
 


### PR DESCRIPTION
## What & why

Fixes #17, #18, and #20 by making the daemon the authoritative owner of polling and streaming watcher lifecycles.

- add an opt-in `x-dormice-watcher-operation-id` UUID for replay-safe polling watcher creation, with canonical request matching and bounded tombstones
- make `RemoveWatcher` a no-wake goal-state operation for every well-formed watcher ID
- retain failed streaming cleanup in the unified watcher registry and retry it on legitimate wake paths
- dispose watcher ownership on stop, destroy, rebuild, reconcile, archive restore, and graceful daemon shutdown
- make the console reuse operation IDs and retry only ambiguous create/remove outcomes
- document compatibility and restart behavior; add a reusable built-daemon verification recipe

Runtime verification against the built fake-executor daemon observed:

- a discarded/replayed create returned the same watcher ID
- mismatched replay returned HTTP 409 `already_exists`
- initial, replayed, unknown-ID remove requests returned HTTP 200; malformed IDs returned HTTP 400
- WatchDir emitted `start` then `deadline_exceeded`
- SIGTERM closed a live WatchDir stream and exited the daemon cleanly
- capacity returned to baseline after stream cleanup; watcher 129 was rejected with HTTP 429

### Linux + Docker + gVisor acceptance

Validated exact head `370376fa8b183a726d96360c5bca03140e86efc4` on Debian 12 with Docker 29.6.2, the `runsc` runtime, and `dormice-base:20260722`:

- DockerExecutor contract: 650/650 server tests passed, including 93/93 Docker contract tests
- official Python E2B sync/async suites: 32 passed, 1 skipped
- `runsc ps` showed replay-safe `CreateWatcher` kept exactly one physical `inotifywait`; mismatched replay stayed at one
- first and replayed `RemoveWatcher` converged to zero physical `inotifywait` processes
- streaming deadline and daemon SIGTERM both closed the HTTP stream and converged to zero `inotifywait` processes
- fault injection paused the runsc sandbox so the first streaming stop could not land; the stream still closed, daemon ownership retained one physical watcher, and the next legitimate wake reaped it to zero
- serialized stability campaign: 10/10 normal watcher cycles, 10/10 forced-stop-failure/wake-reap cycles, and 20/20 repetitions of the previously flaky gVisor command/PTY identity test passed (40/40 total, zero failure markers)

The full Docker E2E suite also exposed a pre-existing test assumption: a test written specifically for the fake executor expects managed swap to be unsupported, while Linux + Docker correctly reports `supported: true`. Running the suite serially produced 94 passed, 2 skipped, and only that unrelated swap assertion failed; all E2B and watcher tests passed. The test host was cleaned and restored after acceptance: zero test containers/mounts/processes and a healthy resident daemon.

## Checklist

- [x] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` passes locally (build first — the e2e suite runs the built daemon)
- [x] Behavior changes come with tests that fail without the change
- [x] User-facing changes to `@dormice/shared` / `sdk` / `cli` have a changeset (`pnpm changeset`) — not applicable; no published package API changed
- [x] README updated if this changes documented behavior — behavior is documented in the E2B differences and upgrading guides
- [x] Linux/Docker/gVisor acceptance on the exact PR head, including physical `inotifywait` inspection and stop-failure fault injection
