### PR TITLE
Give the upgrade socket an error listener before it can be reset

### DIFF
--- a/packages/server/src/executor/fake.ts
+++ b/packages/server/src/executor/fake.ts
@@ -442,6 +442,12 @@ export class FakeExecutor implements Executor {
         );
       });
       upstream.on('upgrade', (_req, socket) => {
+        // The echo pipe's destination is this socket, so a reset reaching
+        // it would re-emit 'error' with no listener and take the daemon
+        // down — the real executor's upstream is another process and
+        // cannot do that, so without this the fake is deadlier than what
+        // it stands in for.
+        socket.on('error', () => socket.destroy());
         socket.write(
           'HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n',
         );

--- a/packages/server/src/sandbox-proxy.test.ts
+++ b/packages/server/src/sandbox-proxy.test.ts
@@ -260,6 +260,111 @@ describe('sandbox port proxy', () => {
     expect(JSON.parse(other.body)).toMatchObject({ sandboxId });
   });
 
+  it('survives a client reset while the upgrade is still waking the sandbox', async () => {
+    const t = await listeningApp();
+    const sandboxId = await createSandbox(t.port);
+    const name = findById(t.db, sandboxId)?.name;
+    if (name === undefined) throw new Error('no sandbox row');
+
+    // Hold the sandbox's lock slot so resolveTarget's own locks.run queues
+    // behind it: the seconds-long window a cold wake really has, made
+    // deterministic. A reset — not a graceful close — is what raises
+    // 'error'; with no listener yet attached it throws out of the
+    // EventEmitter, and the daemon has no uncaughtException handler.
+    let release!: () => void;
+    const occupied = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const slot = t.locks.run(name, () => occupied);
+
+    const crashes: unknown[] = [];
+    const onUncaught = (err: unknown) => crashes.push(err);
+    process.on('uncaughtException', onUncaught);
+    try {
+      const socket = net.connect(t.port, '127.0.0.1', () => {
+        socket.write(
+          [
+            'GET /ws HTTP/1.1',
+            `Host: 5173-${sandboxId}.${DOMAIN}`,
+            'Connection: Upgrade',
+            'Upgrade: websocket',
+            '',
+            '',
+          ].join('\r\n'),
+        );
+      });
+      socket.on('error', () => {
+        // The client end of the reset we are about to send.
+      });
+      // Let the request arrive and park inside handleUpgrade, then reset.
+      await new Promise((r) => setTimeout(r, 100));
+      socket.resetAndDestroy();
+      await new Promise((r) => setTimeout(r, 100));
+      release();
+      await slot;
+      await new Promise((r) => setTimeout(r, 100));
+      expect(crashes).toEqual([]);
+    } finally {
+      process.off('uncaughtException', onUncaught);
+      release();
+    }
+
+    // Still serving: the reset took its own connection down, nothing else.
+    const after = await rawGet(t.port, '/healthz', 'localhost');
+    expect(after.status).toBe(200);
+  });
+
+  it('survives a client reset after the upgrade is established', async () => {
+    const t = await listeningApp();
+    const sandboxId = await createSandbox(t.port);
+
+    // The other half of the window: once the handshake lands, both the
+    // proxy's socket and the upstream's are piped. A reset here reaches
+    // the upstream end too — for the fake that end lives in this process,
+    // so it must be as unkillable as a real container's would be.
+    // Staggered across the handshake rather than one clean case: the reset
+    // has to land while bytes are still moving for the upstream end to see
+    // it as an error, and a single well-timed close does not reproduce it.
+    const crashes: unknown[] = [];
+    const onUncaught = (err: unknown) => crashes.push(err);
+    process.on('uncaughtException', onUncaught);
+    try {
+      await Promise.all(
+        Array.from(
+          { length: 60 },
+          (_, i) =>
+            new Promise<void>((resolve) => {
+              const socket = net.connect(t.port, '127.0.0.1', () => {
+                socket.write(
+                  [
+                    'GET /ws HTTP/1.1',
+                    `Host: 5173-${sandboxId}.${DOMAIN}`,
+                    'Connection: Upgrade',
+                    'Upgrade: websocket',
+                    '',
+                    '',
+                  ].join('\r\n'),
+                );
+                setTimeout(() => {
+                  socket.resetAndDestroy();
+                  resolve();
+                }, i % 10);
+              });
+              socket.on('error', () => resolve());
+              setTimeout(resolve, 3000);
+            }),
+        ),
+      );
+      await new Promise((r) => setTimeout(r, 300));
+      expect(crashes).toEqual([]);
+    } finally {
+      process.off('uncaughtException', onUncaught);
+    }
+
+    const after = await rawGet(t.port, '/healthz', 'localhost');
+    expect(after.status).toBe(200);
+  });
+
   it('passes WebSocket upgrades through, both directions', async () => {
     const t = await listeningApp();
     const sandboxId = await createSandbox(t.port);

--- a/packages/server/src/sandbox-proxy.ts
+++ b/packages/server/src/sandbox-proxy.ts
@@ -209,6 +209,12 @@ export function createSandboxProxy(deps: SandboxProxyDeps): SandboxProxy {
     },
 
     handleUpgrade(req, socket, head) {
+      // The http server drops its own socket error handler before emitting
+      // 'upgrade', so until this line the socket is one reset away from
+      // throwing a listener-less 'error' and taking the daemon with it —
+      // and resolveTarget below can wait seconds on a cold wake. This is
+      // what handleRequest gets for free from its ServerResponse.
+      socket.on('error', () => socket.destroy());
       void (async () => {
         let resolved: Awaited<ReturnType<typeof resolveTarget>>;
         try {
@@ -256,10 +262,8 @@ export function createSandboxProxy(deps: SandboxProxyDeps): SandboxProxy {
           settle();
           socket.destroy();
         });
-        socket.on('error', () => {
-          settle();
-          upstream.destroy();
-        });
+        // No 'error' twin here: the listener above already destroys the
+        // socket, and a destroyed socket always reaches 'close'.
         socket.on('close', () => {
           settle();
           upstream.destroy();


### PR DESCRIPTION
## What & why

Closes #39.

`handleUpgrade` received a bare socket from the http server (which drops its own error handler before emitting `'upgrade'`) and then awaited `resolveTarget` — seconds, on a cold wake — before attaching any listener. A TCP reset in that window is a listener-less `'error'`, which throws; the server installs no `uncaughtException` handler, so the daemon exits and every in-flight exec/restore/archive dies with it.

The listener moves to the first statement, before any await. The `'error'` twin further down is deleted rather than kept alongside it: the new listener destroys the socket, and a destroyed socket always reaches `'close'`, which already runs the same `settle()` + `upstream.destroy()`. Net one listener, not two.

Scope, stated plainly because it first looked worse than it is: only a reset triggers it (a graceful FIN does not), and an HTTP reverse proxy absorbs a client's reset rather than passing it upstream — measured with nginx. With the daemon bound to loopback this is a local robustness defect, not a remotely reachable one, and it hits none of SECURITY.md's three criteria. The realistic trigger is a local client aborting during a wake.

Verifying against a real daemon turned up the same bug a second time, in `FakeExecutor`: its echo upstream self-pipes the upgrade socket with no error listener, so the pipe re-emits `'error'` on a destination with zero listeners when the connection is torn down. The real executor's upstream is a separate process and cannot do this, which made the fake deadlier than what it stands in for.

## Checklist

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean (8 projects)
- [x] `pnpm test` green — server 559 (was 557; +2), console 25, sdk 31, cli 59, e2e 86 pass / 11 skip
- [x] Both new tests verified red without their own fix, green with it
- [x] New tests run 6× consecutively without flaking
- [x] Real-daemon acceptance: built daemon (fake executor, `DORMICE_SANDBOX_DOMAIN` set) survives 120 staggered upgrade-then-reset connections, still serves the proxy afterwards, zero crash traces; normal upgrade still completes 101 + echo. Temp dirs and sandbox cleaned up after.
- [x] No changeset — `packages/server` is private and never published