### PR TITLE
Validate sandbox exec timeout values

### DIFF
--- a/.changeset/green-dormice-count.md
+++ b/.changeset/green-dormice-count.md
@@ -1,0 +1,5 @@
+---
+'@dormice/cli': patch
+---
+
+Reject invalid `sandbox exec --timeout` values with a clear option error.

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const cli = fileURLToPath(new URL('../dist/main.js', import.meta.url));
+
+describe('sandbox exec options', () => {
+  it('rejects a non-numeric timeout at the option boundary', () => {
+    const result = spawnSync(
+      process.execPath,
+      [cli, 'sandbox', 'exec', 'example', 'true', '--timeout', '10m'],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          DORMICE_ENDPOINT: 'http://127.0.0.1:1',
+          DORMICE_API_TOKEN: 'test-token-test-token-test-token',
+        },
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '--timeout must be a positive integer of seconds',
+    );
+    expect(result.stderr).not.toContain('delay');
+  });
+});

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -5,7 +5,7 @@
 // everything testable lives there.
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import {
   apikeyCreate,
   apikeyDisable,
@@ -68,7 +68,15 @@ sandbox
   .option(
     '-t, --timeout <seconds>',
     'kill the command after this many seconds',
-    (value: string) => Number(value),
+    (value: string) => {
+      const timeout = Number(value);
+      if (!Number.isInteger(timeout) || timeout <= 0) {
+        throw new InvalidArgumentError(
+          '--timeout must be a positive integer of seconds',
+        );
+      }
+      return timeout;
+    },
   )
   .action(async (name: string, command: string, opts: { timeout?: number }) => {
     const result = await sandboxExec(


### PR DESCRIPTION
## What & why

Validate `dor sandbox exec --timeout` at Commander's option boundary. Non-integer, non-positive, and non-numeric values now produce a clear `--timeout` error instead of reaching `AbortSignal.timeout` as `NaN` or an invalid delay.

The change includes a black-box CLI regression test and a patch changeset for `@dormice/cli`.

Fixes #33

## Checklist

- [x] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` passes locally (build first — the e2e suite runs the built daemon)
- [x] Behavior changes come with tests that fail without the change
- [x] User-facing changes to `@dormice/shared` / `sdk` / `cli` have a changeset (`pnpm changeset`)
- [ ] README updated if this changes documented behavior (not needed; command syntax is unchanged)

`pnpm lint` completes successfully with six pre-existing non-null assertion warnings in `packages/server/src/db/settings.ts`.
