### PR TITLE
Do not let patch object override the id in updateApiKey

### DIFF
--- a/.changeset/thin-crews-shout.md
+++ b/.changeset/thin-crews-shout.md
@@ -1,0 +1,5 @@
+---
+"@dormice/sdk": patch
+---
+
+Fix `updateApiKey` so a patch object can no longer override the target id. Before this, `{ id, ...patch }` let an `id` field inside `patch` win over the id you pass as the first argument, so the request could edit the wrong key.

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -421,6 +421,30 @@ describe('API keys over real HTTP', () => {
     await client.revokeApiKey(apiKey.id);
   });
 
+  it('updateApiKey ignores an id smuggled inside the patch object', async () => {
+    const { apiKey: intended } = await client.createApiKey('sdk-target');
+    const { apiKey: victim } = await client.createApiKey('sdk-victim');
+
+    // A patch variable can carry an `id` field through structural typing
+    // (TypeScript excess-property checks only catch object literals, not
+    // variables). The wire request must still target the id passed as the
+    // method's own argument, not one hiding inside the patch.
+    const patch = { id: victim.id, disabled: true } as { disabled: boolean };
+    const result = await client.updateApiKey(intended.id, patch);
+
+    expect(result.apiKey.id).toBe(intended.id);
+    expect(result.apiKey.disabledAt).not.toBeNull();
+
+    const allKeys = await client.listApiKeys();
+    const refreshedIntended = allKeys.find((key) => key.id === intended.id);
+    const refreshedVictim = allKeys.find((key) => key.id === victim.id);
+    expect(refreshedIntended?.disabledAt).not.toBeNull();
+    expect(refreshedVictim?.disabledAt).toBeNull();
+
+    await client.revokeApiKey(intended.id);
+    await client.revokeApiKey(victim.id);
+  });
+
   it('a ledger key gets the honest 403 on the management verbs', async () => {
     const { apiKey, token } = await client.createApiKey('sdk-not-admin');
     const keyed = new Dormice({ endpoint, token });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -589,7 +589,11 @@ export class Dormice {
     id: string,
     patch: { name?: string; expiresAt?: string | null; disabled?: boolean },
   ): Promise<UpdateApiKeyResponse> {
-    const data = await this.rpc('updateApiKey', { id, ...patch });
+    // Spread patch first so its fields can never clobber the id we were
+    // explicitly asked to target (a patch variable can carry an `id` of
+    // its own through structural typing, since excess-property checks
+    // only apply to object literals).
+    const data = await this.rpc('updateApiKey', { ...patch, id });
     return updateApiKeyResponseSchema.parse(data);
   }
 


### PR DESCRIPTION
Fixes #76.

## What was wrong

`updateApiKey` build the request body like this:

```ts
const data = await this.rpc('updateApiKey', { id, ...patch });
```

`patch` is spread after `id`, so if the patch object also carry an `id`
field, it win over the real target id. TypeScript do not stop this
because excess-property check only apply to object literals, not to a
variable that is passed in — so a caller can pass a `patch` variable
that structurally has an `id` and the compiler stay quiet.

Effect: an admin who mean to edit key A can end up editing key B
instead, with no error, exactly like the repro in the issue.

## Fix

Swap the spread order so `id` always come from the explicit argument,
never from `patch`:

```ts
const data = await this.rpc('updateApiKey', { ...patch, id });
```

## Test

Added `updateApiKey ignores an id smuggled inside the patch object` in
`packages/sdk/src/client.test.ts`. It create two real keys over the
in-memory server, call `updateApiKey(intended.id, { id: victim.id, disabled: true })`,
and check the intended key get disabled while the victim key stay
untouched. This test fail before the fix and pass after.

Also added a changeset (`@dormice/sdk` patch).

## Checked locally

- `pnpm build`
- `pnpm --filter @dormice/sdk test` — 32 passed (31 before + 1 new)
- `pnpm test` (full monorepo) — all green
- `pnpm typecheck` and `pnpm lint` — clean

I am not a native English speaker, sorry for any small mistake in the wording, the code and test should speak clear enough.