### PR TITLE
Trim the name before matching an API key in disable/enable/revoke

### DIFF
--- a/.changeset/tame-apples-fly.md
+++ b/.changeset/tame-apples-fly.md
@@ -1,0 +1,5 @@
+---
+"@dormice/cli": patch
+---
+
+`dor apikey disable`, `enable` and `revoke` now trim the name argument before matching, the same way key creation trims a name before storing it. Before this, a name typed with the exact leading/trailing whitespace used at creation time (or any other spelling that only differs by whitespace) failed to resolve, so a script or operator could not disable or revoke a credential.

--- a/packages/cli/src/commands.test.ts
+++ b/packages/cli/src/commands.test.ts
@@ -272,6 +272,24 @@ describe('apikey commands over real HTTP', () => {
     );
   });
 
+  it('disable and revoke resolve a name by the same trimmed spelling creation stored', async () => {
+    // Creation trims the name (apiKeyNameSchema), so `ls` and every other
+    // read shows "incident key". Disable/enable/revoke must resolve by
+    // that same trimmed spelling, whether the operator retypes it exactly
+    // or reuses the untrimmed spelling they originally typed at creation.
+    await apikeyCreate(client, '  incident key  ');
+    expect(await apikeyLs(client)).toMatch(/incident key\s{2,}/);
+
+    expect(await apikeyDisable(client, '  incident key  ')).toBe(
+      'Disabled API key "  incident key  " — it stops working until re-enabled.',
+    );
+    expect(await apikeyLs(client)).toMatch(/incident key\s{2,}.*disabled/);
+
+    expect(await apikeyRevoke(client, 'incident key')).toBe(
+      'Revoked API key "incident key" — it stops working immediately.',
+    );
+  });
+
   it('--expires mints a TTL key through end-of-day and refuses garbage dates', async () => {
     const created = await apikeyCreate(client, 'ttl', '2030-06-15');
     expect(created.split('\n')[0]).toMatch(

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -281,8 +281,14 @@ async function resolveApiKeyId(
   client: Dormice,
   name: string,
 ): Promise<string | null> {
+  // Creation trims the name (apiKeyNameSchema), so the stored spelling
+  // never has surrounding whitespace — match on the same trimmed spelling
+  // here so the untrimmed input an operator originally typed still resolves.
+  const trimmed = name.trim();
   const keys = await client.listApiKeys();
-  return keys.find((k) => k.name === name && k.revokedAt === null)?.id ?? null;
+  return (
+    keys.find((k) => k.name === trimmed && k.revokedAt === null)?.id ?? null
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes #77.

## What was wrong

`apiKeyNameSchema` (`z.string().trim().min(1).max(64)`) trim the name
at creation time, so `dor apikey create '  incident key  '` store
`incident key`, and `dor apikey ls` show it that way too.

But `resolveApiKeyId`, the one resolver every management verb use, do
a plain `===` on the raw argument:

```ts
return keys.find((k) => k.name === name && k.revokedAt === null)?.id ?? null;
```

So an operator or a script that reuse the exact spelling they typed at
creation (with the surrounding spaces) get "no API key named ...",
even if the key is listed right there. `revoke` is the worse case: it
answers `revoked: false` instead of throwing, so a credential meant to
be killed can silently stay alive.

## Fix

Trim the name inside `resolveApiKeyId` before the lookup, so it always
compare against the same normalized spelling creation already stored:

```ts
const trimmed = name.trim();
const keys = await client.listApiKeys();
return keys.find((k) => k.name === trimmed && k.revokedAt === null)?.id ?? null;
```

One place fixes it for disable, enable and revoke together, matching
the doctrine already written above that function.

## Test

Added `disable and revoke resolve a name by the same trimmed spelling
creation stored` in `packages/cli/src/commands.test.ts`, following the
issue's own repro: create with extra spaces, disable with the same
untrimmed spelling, then revoke with the trimmed one. Fails before the
fix, passes after.

Also added a changeset (`@dormice/cli` patch).

## Checked locally

- `pnpm build`
- `pnpm --filter @dormice/cli test` — 63 passed
- `pnpm test` (full monorepo) — all green
- `pnpm typecheck` and `pnpm lint` — clean

Sorry in advance for any small English mistake, I am not a native
speaker, but the fix itself is small and the test should make it easy
to check.