### PR TITLE
writeFiles/writeFile: one copy from string to base64, not two

### DIFF
--- a/.changeset/sdk-writefiles-single-copy.md
+++ b/.changeset/sdk-writefiles-single-copy.md
@@ -1,0 +1,5 @@
+---
+'@dormice/sdk': patch
+---
+
+Skip a redundant full-content copy in `writeFiles` / `writeFile`: `Buffer.from` already accepts `string | Uint8Array` and UTF-8-encodes strings natively, so the `TextEncoder.encode` + `Buffer.from` chain was one extra allocation and memcpy per string file on the push hot path. Base64 output is byte-identical.

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -650,11 +650,7 @@ export class Dormice {
       name,
       files: files.map((file) => ({
         path: file.path,
-        contentBase64: Buffer.from(
-          typeof file.content === 'string'
-            ? new TextEncoder().encode(file.content)
-            : file.content,
-        ).toString('base64'),
+        contentBase64: Buffer.from(file.content).toString('base64'),
       })),
     });
     return writeFilesResponseSchema.parse(data);
@@ -672,11 +668,7 @@ export class Dormice {
     const data = await this.rpc('writeFile', {
       name,
       path,
-      contentBase64: Buffer.from(
-        typeof content === 'string'
-          ? new TextEncoder().encode(content)
-          : content,
-      ).toString('base64'),
+      contentBase64: Buffer.from(content).toString('base64'),
     });
     return writeFileResponseSchema.parse(data);
   }


### PR DESCRIPTION
## What & why

Closes #36.

`Buffer.from` already accepts `string | Uint8Array` and UTF-8-encodes a string natively, so the `TextEncoder.encode` + `Buffer.from` chain in `writeFiles` / `writeFile` reimplemented what `Buffer.from` does — one extra full-content allocation and memcpy per string file on the push hot path (up to 16 MiB per file, 32 MiB decoded per batch).

```ts
// before
contentBase64: Buffer.from(
  typeof file.content === 'string'
    ? new TextEncoder().encode(file.content)
    : file.content,
).toString('base64'),

// after
contentBase64: Buffer.from(file.content).toString('base64'),
```

Base64 output is byte-identical:

- **Types**: the `string | Uint8Array` union compiles under `strict` + `noUncheckedIndexedAccess` with the current `tsc` and `@types/node` (`Buffer.from`'s `WithImplicitCoercion<Uint8Array | readonly number[] | string>` overload covers it).
- **Bytes**: identical base64 for multi-byte text, emoji, and a lone surrogate `\ud800` (both Node's utf8 and `TextEncoder` substitute U+FFFD). The existing `'hello 文件'` round-trip in `packages/sdk/src/client.test.ts` pins the behaviour.

The `Uint8Array` branch keeps exactly the same single copy it had before.

## Checklist

- [x] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` passes locally (build first — the e2e suite runs the built daemon)
    - Node 22.22.2 / pnpm 10.30.2: server 681 / console 25 / sdk 31 / cli 64 / e2e 92 tests passed
- [x] Behavior changes come with tests that fail without the change — the existing multi-byte round-trip test already covers the bytes
- [x] User-facing changes to `@dormice/shared` / `sdk` / `cli` have a changeset (`pnpm changeset`)
- [x] README updated if this changes documented behavior — no documented behavior changed