### PR TITLE
formatBytes never emits "1024 <unit>"

### DIFF
--- a/packages/console/src/lib/format.test.ts
+++ b/packages/console/src/lib/format.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatBytes, pctOf } from './format';
+
+describe('formatBytes', () => {
+  it.each([
+    [0, '0 B'],
+    [512, '512 B'],
+    [1023, '1023 B'],
+    [1024, '1.00 KiB'],
+    [1536, '1.50 KiB'],
+    [10 * 1024, '10.0 KiB'],
+    [100 * 1024, '100 KiB'],
+    // Regression: rounding used to push these to the "1024 <unit>" string
+    // even though every element in the string exists at the next unit.
+    // Each value is one unit below the next power of 1024 by 276 sub-units —
+    // enough that toFixed(0) rounds the display up to 1024 without the check.
+    [1048300, '1.00 MiB'],
+    [1073459200, '1.00 GiB'],
+    [1099509530624, '1.00 TiB'],
+  ])('formats %s as %s', (bytes, expected) => {
+    expect(formatBytes(bytes)).toBe(expected);
+  });
+
+  it('never prints 1024 of any unit', () => {
+    // Sweep every unit boundary from the half-KiB below through the boundary.
+    const boundaries = [1024, 1024 ** 2, 1024 ** 3, 1024 ** 4, 1024 ** 5];
+    for (const boundary of boundaries) {
+      for (let delta = 0; delta < 600; delta += 1) {
+        const bytes = boundary - delta;
+        expect(formatBytes(bytes)).not.toMatch(/^1024 /);
+      }
+    }
+  });
+
+  it('handles non-finite and negative inputs', () => {
+    expect(formatBytes(Number.NaN)).toBe('—');
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBe('—');
+    expect(formatBytes(-1)).toBe('—');
+  });
+});
+
+describe('pctOf', () => {
+  it('clamps to [0, 100]', () => {
+    expect(pctOf(0, 100)).toBe(0);
+    expect(pctOf(50, 100)).toBe(50);
+    expect(pctOf(150, 100)).toBe(100);
+    expect(pctOf(-1, 100)).toBe(0);
+  });
+
+  it('returns 0 for a non-positive total', () => {
+    expect(pctOf(5, 0)).toBe(0);
+    expect(pctOf(5, -10)).toBe(0);
+  });
+});

--- a/packages/console/src/lib/format.ts
+++ b/packages/console/src/lib/format.ts
@@ -15,7 +15,15 @@ export function formatBytes(bytes: number): string {
     value /= 1024;
     unit += 1;
   }
-  const digits = value >= 100 || unit === 0 ? 0 : value >= 10 ? 1 : 2;
+  let digits = value >= 100 || unit === 0 ? 0 : value >= 10 ? 1 : 2;
+  // Rounding at the chosen precision can push value back up to the next unit
+  // (e.g. 1023.73 KiB → "1024 KiB"). Re-check after toFixed and promote once
+  // so "1024 <unit>" is never emitted.
+  if (Number(value.toFixed(digits)) >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+    digits = 2;
+  }
   return `${value.toFixed(digits)} ${units[unit]}`;
 }
 


### PR DESCRIPTION
## What & why

Closes #92.

`formatBytes` promotes units while `value >= 1024`, but the `toFixed` rounding happens **after** the loop exits. Anything in `[1023.5, 1024)` at the chosen precision rounds back up to `\"1024 <unit>\"` instead of continuing to `\"1.00 <next unit>\"`. Every boundary is affected: `1048300` → `\"1024 KiB\"`, `1073459200` → `\"1024 MiB\"`, up through TiB. It reads as a bug to anyone who knows the units (`du -h` never prints `\"1024 MiB\"`) and it breaks column alignment since the string is one character wider than every neighbour.

### The fix

Re-check at the chosen precision and promote once:

```ts
let digits = value >= 100 || unit === 0 ? 0 : value >= 10 ? 1 : 2;
if (Number(value.toFixed(digits)) >= 1024 && unit < units.length - 1) {
  value /= 1024;
  unit += 1;
  digits = 2;
}
return \`\${value.toFixed(digits)} \${units[unit]}\`;
```

One promotion is enough: after `/=1024`, `value` is in `[1, 2)`, so the next iteration can never round back up.

### Tests

Adds `packages/console/src/lib/format.test.ts`:

- **Per-boundary regressions**: `1048300 → \"1.00 MiB\"`, `1073459200 → \"1.00 GiB\"`, `1099509530624 → \"1.00 TiB\"`. Each is one unit below the next power of 1024 by 276 sub-units — enough that `toFixed(0)` rounds the display up to 1024 without the check.
- **Delta sweep** (KiB..PiB × 600 deltas): asserts no unit ever renders `\"1024 \"`.
- Existing table cases for regular values, plus non-finite / negative inputs.

Confirmed the test **fails on unpatched code** (4 cases) and **passes with the fix** (39/39).

`pctOf` is left alone (issue mentioned same class of exposure; keeping this PR to one thing).

## Checklist

- [x] \`pnpm build && pnpm typecheck && pnpm lint && pnpm test\` passes locally (build first — the e2e suite runs the built daemon)
    - console 39 / server 681 / sdk 31 / cli 64 / e2e 92
- [x] Behavior changes come with tests that fail without the change
- [ ] User-facing changes to \`@dormice/shared\` / \`sdk\` / \`cli\` have a changeset — not applicable, \`@dormice/console\` is a private package
- [ ] README updated if this changes documented behavior — not applicable