### PR TITLE
Handle broken CLI output pipes

### DIFF
--- a/.changeset/quiet-broken-pipes.md
+++ b/.changeset/quiet-broken-pipes.md
@@ -1,0 +1,5 @@
+---
+'@dormice/cli': patch
+---
+
+Handle closed stdout and stderr pipes quietly while preserving sandbox command exit codes.

--- a/e2e/src/cli.test.ts
+++ b/e2e/src/cli.test.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -28,6 +28,28 @@ function cli(...args: string[]) {
       DORMICE_API_TOKEN: inject('dormiceToken'),
     },
   });
+}
+
+function cliWithClosedStdout(...args: string[]) {
+  return new Promise<{ code: number | null; stderr: string }>(
+    (resolve, reject) => {
+      const child = spawn('node', [CLI, ...args], {
+        env: {
+          ...process.env,
+          DORMICE_ENDPOINT: inject('dormiceEndpoint'),
+          DORMICE_API_TOKEN: inject('dormiceToken'),
+        },
+      });
+      let stderr = '';
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk: string) => {
+        stderr += chunk;
+      });
+      child.stdout.once('data', () => child.stdout.destroy());
+      child.once('error', reject);
+      child.once('close', (code) => resolve({ code, stderr }));
+    },
+  );
 }
 
 describe('dor CLI against a real daemon', () => {
@@ -105,6 +127,23 @@ describe('dor CLI against a real daemon', () => {
     await expect(
       cli('sandbox', 'exec', 'cli-exec-key', 'exit 3'),
     ).rejects.toMatchObject({ code: 3 });
+  });
+
+  it('keeps the sandbox exit code when downstream closes stdout early', async () => {
+    const sdk = new Dormice({
+      endpoint: inject('dormiceEndpoint'),
+      token: inject('dormiceToken'),
+    });
+    await sdk.acquireSandbox('cli-broken-pipe-key');
+
+    const result = await cliWithClosedStdout(
+      'sandbox',
+      'exec',
+      'cli-broken-pipe-key',
+      'seq 1 300000; exit 3',
+    );
+    expect(result.code).toBe(3);
+    expect(result.stderr).not.toContain('EPIPE');
   });
 
   it('sandbox push and pull move a file in and back out through the real binary', async () => {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -28,6 +28,15 @@ import {
 } from './commands';
 import { realDoctorContext, runDoctor } from './doctor';
 
+// A downstream command such as `head` may close either pipe while output is
+// still buffered. EPIPE is normal in that case; leaving the process alive also
+// preserves `sandbox exec`'s own exit code. Every other stream error stays fatal.
+for (const stream of [process.stdout, process.stderr]) {
+  stream.on('error', (error: NodeJS.ErrnoException) => {
+    if (error.code !== 'EPIPE') throw error;
+  });
+}
+
 const program = new Command('dor').description(
   'Command-line tool for a Dormice daemon (also installed as `dormice`)',
 );


### PR DESCRIPTION
## What & why

Handle `EPIPE` from both CLI output streams as a normal closed-pipeline outcome instead of an uncaught exception.

The handler deliberately ignores only `EPIPE` and does not call `process.exit(0)`. That lets `sandbox exec` keep the sandbox command's own exit code after a downstream consumer such as `head` closes stdout early; unrelated stream failures remain fatal.

The new black-box regression test runs the built CLI against the real test daemon, closes stdout during a 1 MiB write, and verifies that the sandbox's exit code 3 survives without an `EPIPE` stack trace.

Fixes #48

## Checklist

- [ ] `pnpm build && pnpm typecheck && pnpm lint && pnpm test` passes locally (the affected chain passes; unrelated Windows blockers are listed below)
- [x] Behavior changes come with tests that fail without the change
- [x] User-facing changes to `@dormice/cli` have a changeset
- [x] README is unchanged because this restores normal shell pipeline behavior rather than adding a command or option

## Verification

Passed locally on Node 24.10.0 / pnpm 10.30.2:

- `pnpm --filter @dormice/cli... build`
- `pnpm typecheck`
- `pnpm exec biome lint .`
- Biome check for all changed source/test files
- `pnpm --filter @dormice/cli test` (64 tests)
- `pnpm --filter @dormice/e2e exec vitest run src/cli.test.ts` (9 tests)

The full root chain is not green on this Windows checkout for pre-existing platform assumptions: the website build uses POSIX environment assignment and its docs generator sees CRLF frontmatter, while unrelated server/e2e tests rely on Unix commands or symlink privileges. No failures are in the changed CLI code or regression test; CI can run the complete Linux chain.