### PR TITLE
fix: directory watches now use the requested user, not always the default

### DIFF
--- a/.changeset/tidy-rivers-hunt.md
+++ b/.changeset/tidy-rivers-hunt.md
@@ -1,0 +1,5 @@
+---
+"@dormice/server": patch
+---
+
+Directory watches (`WatchDir` and the polling `CreateWatcher`) now read and validate the `user` option the SDKs send over Basic auth, the same way every other filesystem verb already does. Before this, the authorization header was ignored and every watch ran as the default user, so `watchDir(..., { user: 'root' })` against a root-only tree failed, and an unsupported username was accepted instead of being rejected like it is for `Stat`, `ListDir`, and the rest.

--- a/packages/server/src/e2b/compat.test.ts
+++ b/packages/server/src/e2b/compat.test.ts
@@ -1482,6 +1482,7 @@ describe('E2B envd surface', () => {
     sandboxID: string,
     body: Record<string, unknown>,
     deadlineMs: number,
+    headers: Record<string, string> = {},
   ) {
     return t.app.inject({
       method: 'POST',
@@ -1490,6 +1491,7 @@ describe('E2B envd surface', () => {
         ...envdHeaders(t, sandboxID),
         'content-type': 'application/connect+json',
         'connect-timeout-ms': String(deadlineMs),
+        ...headers,
       },
       payload: enveloped(body),
     });
@@ -1582,6 +1584,58 @@ describe('E2B envd surface', () => {
     expect(fileFrames[0]?.json.error).toEqual({
       code: 'invalid_argument',
       message: 'not a directory: /home/user/plain.txt',
+    });
+  });
+
+  it('WatchDir vets the requested user like every other filesystem verb', async () => {
+    const t = testApp();
+    const { sandboxID } = await createSandbox(t);
+    const basic = (name: string) => ({
+      authorization: `Basic ${Buffer.from(`${name}:`).toString('base64')}`,
+    });
+
+    // Unknown name: refused before any start frame, same shape as Start.
+    const refused = await watchDir(
+      t,
+      sandboxID,
+      { path: '/home/user' },
+      500,
+      basic('nobody'),
+    );
+    const frames = parseEnvelopes(refused.rawPayload);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toEqual({
+      flags: 2,
+      json: {
+        error: {
+          code: 'unauthenticated',
+          message: "invalid username: 'nobody'",
+        },
+      },
+    });
+    expect(t.watchers.count(sandboxID)).toBe(0);
+
+    // A supported name still opens the watch normally.
+    const asRoot = await watchDir(
+      t,
+      sandboxID,
+      { path: '/home/user' },
+      500,
+      basic('root'),
+    );
+    expect(parseEnvelopes(asRoot.rawPayload)[0]?.json).toEqual({ start: {} });
+
+    // The unary polling face vets the same way.
+    const created = await t.app.inject({
+      method: 'POST',
+      url: '/e2b/envd/filesystem.Filesystem/CreateWatcher',
+      headers: { ...envdHeaders(t, sandboxID), ...basic('nobody') },
+      payload: { path: '/home/user' },
+    });
+    expect(created.statusCode).toBe(401);
+    expect(created.json()).toEqual({
+      code: 'unauthenticated',
+      message: "invalid username: 'nobody'",
     });
   });
 

--- a/packages/server/src/e2b/envd/watch.ts
+++ b/packages/server/src/e2b/envd/watch.ts
@@ -24,6 +24,8 @@ import {
   rawWriter,
   sandboxIdOf,
   streamError,
+  usernameOf,
+  vetUsername,
   wireDeadlineMs,
 } from './shared';
 
@@ -111,6 +113,15 @@ export function registerWatchRoutes(
     if (!message.path) {
       return streamError(reply, 'invalid_argument', 'missing path');
     }
+    // Identity rides the Basic auth header (SDK: user option); vetted here,
+    // in the streaming dialect, before anything wakes — same as Start.
+    let user: string | undefined;
+    try {
+      user = vetUsername(usernameOf(request));
+    } catch (error) {
+      const e = error as { code: string | number; message: string };
+      return streamError(reply, String(e.code), e.message);
+    }
     const sandboxId = sandboxIdOf(request);
     let reservationId: string;
     try {
@@ -153,6 +164,7 @@ export function registerWatchRoutes(
         reservationId,
         path: message.path,
         recursive: message.recursive === true,
+        user,
         onEvent: async (event) => {
           await opened;
           await write(
@@ -247,6 +259,8 @@ export function registerWatchRoutes(
     const body = request.body as { path?: string; recursive?: boolean };
     if (!body.path) throw connectError('invalid_argument', 'missing path');
     const path = body.path;
+    // Same identity as the other filesystem verbs, vetted the same way.
+    const user = vetUsername(usernameOf(request));
     const operationId = operationIdOf(request);
     return ctx.inSlot(sandboxIdOf(request), async (row) => {
       try {
@@ -255,6 +269,7 @@ export function registerWatchRoutes(
           sandboxId: row.id,
           path,
           recursive: body.recursive === true,
+          user,
           operationId,
         });
         return { watcherId };

--- a/packages/server/src/e2b/watcher-table.test.ts
+++ b/packages/server/src/e2b/watcher-table.test.ts
@@ -54,6 +54,38 @@ describe('WatcherTable', () => {
     await Promise.all(starts);
   });
 
+  it('passes the requested user through to the executor, for both create and createStreaming', async () => {
+    const executor = {
+      watchDir: vi.fn().mockResolvedValue({ stop: async () => {} }),
+    } as unknown as Executor;
+    const table = new WatcherTable();
+
+    await table.create({ ...args(executor), user: 'root' });
+    expect(executor.watchDir).toHaveBeenLastCalledWith(
+      'sandbox-1',
+      expect.objectContaining({ user: 'root' }),
+    );
+
+    await table.createStreaming({
+      ...args(executor),
+      user: 'root',
+      onEvent: () => {},
+      onEnd: () => {},
+    });
+    expect(executor.watchDir).toHaveBeenLastCalledWith(
+      'sandbox-1',
+      expect.objectContaining({ user: 'root' }),
+    );
+
+    // Omitted stays omitted — the executor falls back to its own default,
+    // the same as every other filesystem verb.
+    await table.create(args(executor));
+    expect(executor.watchDir).toHaveBeenLastCalledWith(
+      'sandbox-1',
+      expect.objectContaining({ user: undefined }),
+    );
+  });
+
   it('releases a reservation when start fails', async () => {
     const executor = {
       watchDir: vi.fn().mockRejectedValueOnce(new Error('start failed')),

--- a/packages/server/src/e2b/watcher-table.ts
+++ b/packages/server/src/e2b/watcher-table.ts
@@ -85,6 +85,8 @@ interface CreateArgs {
   sandboxId: string;
   path: string;
   recursive: boolean;
+  /** Same identity as the other filesystem verbs; absent means the default user. */
+  user?: string;
   operationId?: string;
 }
 
@@ -391,6 +393,7 @@ export class WatcherTable {
       const handle = await args.executor.watchDir(args.sandboxId, {
         path: resolveSandboxPath(args.path),
         recursive: args.recursive,
+        user: args.user,
         onEvent,
         onEnd: (error) => {
           record.endError = error;

--- a/packages/server/src/executor/docker.ts
+++ b/packages/server/src/executor/docker.ts
@@ -1553,6 +1553,7 @@ export class DockerExecutor implements Executor {
       ],
       stdout: new CallbackSink(onStdout),
       stderr: new CallbackSink(onStderr),
+      user: opts.user,
     });
     const exitInfo = started.wait().then(
       (exitCode) => ({ exitCode, error: undefined as Error | undefined }),

--- a/packages/server/src/executor/executor.ts
+++ b/packages/server/src/executor/executor.ts
@@ -149,6 +149,8 @@ export interface WatchDirOptions {
   path: string;
   /** Watch the whole subtree; directories created later are picked up too. */
   recursive: boolean;
+  /** Same identity as the other filesystem verbs; absent means the default user. */
+  user?: string;
   /** A returned promise is awaited before the next event: backpressure. */
   onEvent: (event: WatchEvent) => void | Promise<void>;
   /**


### PR DESCRIPTION
fixes #83

`WatchDir` (streaming) and `CreateWatcher` (polling) never read the `Authorization: Basic` header the SDKs send for the `user` option. every other filesystem verb (Stat, ListDir, MakeDir, Remove...) already vet this the same way, but watch skip it, so:

- a watch requested with `user: 'root'` always run as the default `user` instead, so a root-only tree could not be watched.
- an unsupported username was accepted and silently ran as default, instead of getting the same `invalid username: '<name>'` refusal the other verbs give.

what i change:
- `watch.ts`: both routes now call `vetUsername(usernameOf(request))` before starting anything, same pattern the `Start` streaming route already use for exec.
- `WatchDirOptions` (executor.ts) get an optional `user` field.
- `WatcherTable.create`/`createStreaming` thread `user` through to `executor.watchDir`.
- `docker.ts` pass it to `startInContainer` (it already support a `user` option, just nobody was giving it one for watch).

did not touch the fake executor's watch behavior itself — like the existing comment in fake.ts explain, the fake deliberately don't model real unix permissions, only the docker executor does, so i only make sure the value reach the executor call correctly (test with a mock executor) plus that the vetting/refuse behavior on the route match the other verbs exactly (this part is real behavior, testable without docker).

tests:
- `watcher-table.test.ts`: new test that `user` passed to `create`/`createStreaming` reach `executor.watchDir`'s opts, and stays `undefined` when not given.
- `compat.test.ts`: new test mirroring the existing "user rides Basic auth" test — both watch faces refuse `nobody` the same way `Stat` does, and `root` still works normally.

ran locally: typecheck, lint, build, and the full server test suite all pass (`pnpm --filter @dormice/server test` — 683 passed).

note: i used Claude Code to help write and test this.